### PR TITLE
Added support for LESS

### DIFF
--- a/octicons/octicons.less
+++ b/octicons/octicons.less
@@ -1,10 +1,5 @@
-@import "variables.less";
-@import "path.less";
-@import "core.less";
-@import "icons.less";
-
 @octicon-font-path: ".";
-@octicon-version:    "2.0.2";
+@octicon-version:   "2.0.2";
 
 @font-face {
   font-family: 'octicons';


### PR DESCRIPTION
This adds support fort `LESS`, so that `octicon` font it can be used when building css from source.
Initially made this in order to be able to override location of font files.
