### PR TITLE
Add README to /octicons directory with important notes

### DIFF
--- a/octicons/README.md
+++ b/octicons/README.md
@@ -1,1 +1,1 @@
-Note: This directory contains several versions of Octicons for different purposes. If you want to use Octicons for your own project, it's best to use the generator at [octicons.github.com](http://octicons.github.com/).
+If you intend to install Octicons locally, install `octicons-local.ttf`. It should appear as “github-octicons” in your font list. It is specially designed not to conflict with GitHub's web fonts.


### PR DESCRIPTION
This README can contain important clarification about how to use this directory for users who might land here not realizing that a) it contains versions of Octicons for different purposes (web vs local), and b) http://octicons.github.com exists as the best place to download the fonts.

Note that I've just stubbed out the important content, and more could/should maybe be added to this.
