### PR TITLE
Added ignore to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,5 +19,9 @@
     "font",
     "web font",
     "icon font"
+  ],
+  "ignore": [
+    "**/.*",
+    "bower_components"
   ]
 }


### PR DESCRIPTION
If ignore is missing, you'll see the following warning while installing "octicons":

bower invalid-meta  octicons is missing "ignore" entry in bower.json
