### PR TITLE
Making CSS declaration more terse

### DIFF
--- a/octicons/octicons.css
+++ b/octicons/octicons.css
@@ -15,9 +15,10 @@
 
 */
 .octicon, .mega-octicon {
-  font: normal normal 16px/1 octicons;
+  font: normal normal normal 16px/1 octicons;
   display: inline-block;
   text-decoration: none;
+  text-rendering: auto;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-user-select: none;

--- a/octicons/octicons.less
+++ b/octicons/octicons.less
@@ -14,9 +14,10 @@
 // .octicon is optimized for 16px.
 // .mega-octicon is optimized for 32px but can be used larger.
 .octicon, .mega-octicon {
-  font: normal normal 16px/1 octicons;
+  font: normal normal normal 16px/1 octicons;
   display: inline-block;
   text-decoration: none;
+  text-rendering: auto;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-user-select: none;

--- a/octicons/sprockets-octicons.scss
+++ b/octicons/sprockets-octicons.scss
@@ -11,9 +11,10 @@
 // .octicon is optimized for 16px.
 // .mega-octicon is optimized for 32px but can be used larger.
 .octicon, .mega-octicon {
-  font: normal normal 16px/1 octicons;
+  font: normal normal normal 16px/1 octicons;
   display: inline-block;
   text-decoration: none;
+  text-rendering: auto;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-user-select: none;


### PR DESCRIPTION
This is an attempt to shorten up the CSS for octicons. I'm doing something similar for Font Awesome right now, and thought I'd see if this looked interesting.

I'm also putting in a couple of other improvements due to past FA issues. I thought these could also be of interest:

```
font-variant: normal;
text-rendering: auto;
```

If you like, I can add them to the PR, too. And if there's somewhere else I should be making this PR, let me know.
