### PR TITLE
Include style property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.3.0",
   "description": "GitHub's icon font",
   "main": "README.md",
+  "style": "octicons/octicons.css",
   "repository": {
     "type": "git",
     "url": "https://github.com/github/octicons.git"


### PR DESCRIPTION
Adds a `style` property in the `package.json` file to support tools that look for the main css file of the module.

I personally needed it for [cssnext](https://github.com/MoOx/cssnext) which uses [postcss-import](https://github.com/postcss/postcss-import) to `@import` npm modules. Seems to be relatively common [elsewhere too](http://stackoverflow.com/a/32042285/26401), notably used by [bootstrap](https://github.com/twbs/bootstrap/blob/master/package.json#L20).