### PR TITLE
Revert license to SPDX format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Adds:
 
 - Installation docs https://github.com/primer/octicons/pull/94
 
+Fixes:
+
+- Revert license back to SPDX standard
+
 ### 4.0.0 (June 6, 2016)
 
 Adds:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",
   "author": "GitHub Inc.",
-  "license": "(OFL-1.1 AND MIT)",
+  "license": "(OFL-1.1 OR MIT)",
   "style": "index.scss",
   "files": [
     "index.scss",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",
   "author": "GitHub Inc.",
-  "license": [
-    "OFL-1.1",
-    "MIT"
-  ],
+  "license": "(OFL-1.1 AND MIT)",
   "style": "index.scss",
   "files": [
     "index.scss",


### PR DESCRIPTION
Changing the license to an array created some problems in https://github.com/primer/octicons/issues/85#issuecomment-224108061

The reverts back to the SPDX syntax. 