### PR TITLE
Adding a keywords map and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### HEAD
+
+Adds:
+
+- Keywords.json file that has an index of all octicons with alias names
+
 ### 4.1.1 (June 16, 2016)
 
 Fixes:

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  keywords: require('./lib/keywords'),
+  codepoints: require('./lib/font/codepoints')
+}

--- a/lib/font/codepoints.json
+++ b/lib/font/codepoints.json
@@ -97,7 +97,6 @@
     "lock": 61546,
     "logo-gist": 61613,
     "logo-github": 61586,
-    "logo-octicons": 61611,
     "mail": 61499,
     "mail-read": 61500,
     "mail-reply": 61521,

--- a/lib/keywords.json
+++ b/lib/keywords.json
@@ -1,0 +1,1134 @@
+{
+  "alert": {
+    "keywords": [
+      "warning",
+      "triangle",
+      "exclamation",
+      "point"
+    ]
+  },
+  "arrow-down": {
+    "keywords": [
+      "point",
+      "direction"
+    ]
+  },
+  "arrow-left": {
+    "keywords": [
+      "point",
+      "direction"
+    ]
+  },
+  "arrow-right": {
+    "keywords": [
+      "point",
+      "direction"
+    ]
+  },
+  "arrow-small-down": {
+    "keywords": [
+      "point",
+      "direction"
+    ]
+  },
+  "arrow-small-left": {
+    "keywords": [
+      "point",
+      "direction",
+      "little",
+      "tiny"
+    ]
+  },
+  "arrow-small-right": {
+    "keywords": [
+      "point",
+      "direction",
+      "little",
+      "tiny"
+    ]
+  },
+  "arrow-small-up": {
+    "keywords": [
+      "point",
+      "direction",
+      "little",
+      "tiny"
+    ]
+  },
+  "arrow-up": {
+    "keywords": [
+      "point",
+      "direction"
+    ]
+  },
+  "beaker": {
+    "keywords": [
+      "experiment",
+      "labs",
+      "experimental",
+      "feature",
+      "test",
+      "science",
+      "education",
+      "study",
+      "development",
+      "testing"
+    ]
+  },
+  "bell": {
+    "keywords": [
+      "notification"
+    ]
+  },
+  "bold": {
+    "keywords": [
+      ""
+    ]
+  },
+  "book": {
+    "keywords": [
+      "book",
+      "journal",
+      "wiki",
+      "readme"
+    ]
+  },
+  "bookmark": {
+    "keywords": [
+      "tabbard"
+    ]
+  },
+  "briefcase": {
+    "keywords": [
+      "suitcase",
+      "business"
+    ]
+  },
+  "broadcast": {
+    "keywords": [
+      "rss",
+      "radio",
+      "signal"
+    ]
+  },
+  "browser": {
+    "keywords": [
+      "window",
+      "web"
+    ]
+  },
+  "bug": {
+    "keywords": [
+      "insect"
+    ]
+  },
+  "calendar": {
+    "keywords": [
+      "time",
+      "day",
+      "month",
+      "year"
+    ]
+  },
+  "check": {
+    "keywords": [
+      "mark",
+      "yes",
+      "confirm",
+      "accept",
+      "ok",
+      "success"
+    ]
+  },
+  "checklist": {
+    "keywords": [
+      "todo"
+    ]
+  },
+  "chevron-down": {
+    "keywords": [
+      "triangle",
+      "arrow"
+    ]
+  },
+  "chevron-left": {
+    "keywords": [
+      "triangle",
+      "arrow"
+    ]
+  },
+  "chevron-right": {
+    "keywords": [
+      "triangle",
+      "arrow"
+    ]
+  },
+  "chevron-up": {
+    "keywords": [
+      "triangle",
+      "arrow"
+    ]
+  },
+  "circle-slash": {
+    "keywords": [
+      "no",
+      "deny",
+      "fail",
+      "failure",
+      "error",
+      "bad"
+    ]
+  },
+  "circuit-board": {
+    "keywords": [
+      "developer",
+      "hardware",
+      "electricity"
+    ]
+  },
+  "clippy": {
+    "keywords": [
+      "copy",
+      "paste",
+      "save",
+      "capture"
+    ]
+  },
+  "clock": {
+    "keywords": [
+      "time",
+      "hour",
+      "minute",
+      "second"
+    ]
+  },
+  "cloud-download": {
+    "keywords": [
+      "save",
+      "install",
+      "get"
+    ]
+  },
+  "cloud-upload": {
+    "keywords": [
+      "put",
+      "export"
+    ]
+  },
+  "code": {
+    "keywords": [
+      "brackets"
+    ]
+  },
+  "comment": {
+    "keywords": [
+      "speak",
+      "bubble"
+    ]
+  },
+  "comment-discussion": {
+    "keywords": [
+      "converse",
+      "talk"
+    ]
+  },
+  "credit-card": {
+    "keywords": [
+      "money",
+      "billing",
+      "payments",
+      "transactions"
+    ]
+  },
+  "dash": {
+    "keywords": [
+      "hyphen",
+      "range"
+    ]
+  },
+  "dashboard": {
+    "keywords": [
+      "speed",
+      "dial"
+    ]
+  },
+  "database": {
+    "keywords": [
+      "disks",
+      "data"
+    ]
+  },
+  "desktop-download": {
+    "keywords": [
+      "clone",
+      "download"
+    ]
+  },
+  "device-camera": {
+    "keywords": [
+      "photo",
+      "picture",
+      "image",
+      "snapshot"
+    ]
+  },
+  "device-camera-video": {
+    "keywords": [
+      "watch",
+      "view",
+      "media",
+      "stream"
+    ]
+  },
+  "device-desktop": {
+    "keywords": [
+      "computer",
+      "monitor"
+    ]
+  },
+  "device-mobile": {
+    "keywords": [
+      "phone",
+      "iphone",
+      "cellphone"
+    ]
+  },
+  "diff": {
+    "keywords": [
+      "difference",
+      "changes",
+      "compare"
+    ]
+  },
+  "diff-added": {
+    "keywords": [
+      "new",
+      "addition"
+    ]
+  },
+  "diff-ignored": {
+    "keywords": [
+      "slash"
+    ]
+  },
+  "diff-modified": {
+    "keywords": [
+      "dot",
+      "changed",
+      "updated"
+    ]
+  },
+  "diff-removed": {
+    "keywords": [
+      "deleted",
+      "subtracted",
+      "dash"
+    ]
+  },
+  "diff-renamed": {
+    "keywords": [
+      "moved",
+      "arrow"
+    ]
+  },
+  "ellipsis": {
+    "keywords": [
+      "read",
+      "more",
+      "hidden",
+      "expand"
+    ]
+  },
+  "eye": {
+    "keywords": [
+      "look",
+      "watch",
+      "see"
+    ]
+  },
+  "file-binary": {
+    "keywords": [
+      "image",
+      "video",
+      "word",
+      "powerpoint",
+      "excel"
+    ]
+  },
+  "file-code": {
+    "keywords": [
+      "text",
+      "javascript",
+      "html",
+      "css",
+      "php",
+      "ruby",
+      "coffeescript",
+      "sass",
+      "scss"
+    ]
+  },
+  "file-directory": {
+    "keywords": [
+      "folder"
+    ]
+  },
+  "file-media": {
+    "keywords": [
+      "image",
+      "video",
+      "audio"
+    ]
+  },
+  "file-pdf": {
+    "keywords": [
+      "adobe"
+    ]
+  },
+  "file-submodule": {
+    "keywords": [
+      "folder"
+    ]
+  },
+  "file-symlink-directory": {
+    "keywords": [
+      "folder",
+      "subfolder",
+      "link",
+      "alias"
+    ]
+  },
+  "file-symlink-file": {
+    "keywords": [
+      "link",
+      "alias"
+    ]
+  },
+  "file-text": {
+    "keywords": [
+      "document"
+    ]
+  },
+  "file-zip": {
+    "keywords": [
+      "compress",
+      "archive"
+    ]
+  },
+  "flame": {
+    "keywords": [
+      "fire",
+      "hot",
+      "burn",
+      "trending"
+    ]
+  },
+  "fold": {
+    "keywords": [
+      "unfold",
+      "hide",
+      "collapse"
+    ]
+  },
+  "gear": {
+    "keywords": [
+      "settings"
+    ]
+  },
+  "gift": {
+    "keywords": [
+      "package",
+      "present",
+      "skill",
+      "craft",
+      "freebie"
+    ]
+  },
+  "gist": {
+    "keywords": [
+      ""
+    ]
+  },
+  "gist-secret": {
+    "keywords": [
+      ""
+    ]
+  },
+  "git-branch": {
+    "keywords": [
+      ""
+    ]
+  },
+  "git-commit": {
+    "keywords": [
+      "save"
+    ]
+  },
+  "git-compare": {
+    "keywords": [
+      "difference",
+      "changes"
+    ]
+  },
+  "git-merge": {
+    "keywords": [
+      "join"
+    ]
+  },
+  "git-pull-request": {
+    "keywords": [
+      "review"
+    ]
+  },
+  "globe": {
+    "keywords": [
+      "world"
+    ]
+  },
+  "graph": {
+    "keywords": [
+      "trend",
+      "stats",
+      "statistics"
+    ]
+  },
+  "heart": {
+    "keywords": [
+      "love"
+    ]
+  },
+  "history": {
+    "keywords": [
+      "time",
+      "past",
+      "revert",
+      "back"
+    ]
+  },
+  "home": {
+    "keywords": [
+      "welcome",
+      "index",
+      "house",
+      "building"
+    ]
+  },
+  "horizontal-rule": {
+    "keywords": [
+      "hr"
+    ]
+  },
+  "hubot": {
+    "keywords": [
+      "robot"
+    ]
+  },
+  "inbox": {
+    "keywords": [
+      "mail",
+      "todo",
+      "new",
+      "messages"
+    ]
+  },
+  "info": {
+    "keywords": [
+      "help"
+    ]
+  },
+  "issue-closed": {
+    "keywords": [
+      "done",
+      "complete"
+    ]
+  },
+  "issue-opened": {
+    "keywords": [
+      "new"
+    ]
+  },
+  "issue-reopened": {
+    "keywords": [
+      "regression"
+    ]
+  },
+  "italic": {
+    "keywords": [
+      ""
+    ]
+  },
+  "jersey": {
+    "keywords": [
+      "team",
+      "game",
+      "basketball"
+    ]
+  },
+  "key": {
+    "keywords": [
+      "key",
+      "lock",
+      "secure",
+      "safe"
+    ]
+  },
+  "keyboard": {
+    "keywords": [
+      "type",
+      "keys",
+      "write",
+      "shortcuts"
+    ]
+  },
+  "law": {
+    "keywords": [
+      ""
+    ]
+  },
+  "light-bulb": {
+    "keywords": [
+      "idea"
+    ]
+  },
+  "link": {
+    "keywords": [
+      "connect",
+      "hyperlink"
+    ]
+  },
+  "link-external": {
+    "keywords": [
+      "out",
+      "see",
+      "more",
+      "go",
+      "to"
+    ]
+  },
+  "list-ordered": {
+    "keywords": [
+      "numbers",
+      "tasks",
+      "todo",
+      "items"
+    ]
+  },
+  "list-unordered": {
+    "keywords": [
+      "bullet",
+      "point",
+      "tasks",
+      "todo",
+      "items"
+    ]
+  },
+  "location": {
+    "keywords": [
+      "here",
+      "marker"
+    ]
+  },
+  "lock": {
+    "keywords": [
+      "secure",
+      "safe",
+      "protected"
+    ]
+  },
+  "logo-gist": {
+    "keywords": [
+      ""
+    ]
+  },
+  "logo-github": {
+    "keywords": [
+      "brand"
+    ]
+  },
+  "mail": {
+    "keywords": [
+      "email",
+      "unread"
+    ]
+  },
+  "mail-read": {
+    "keywords": [
+      "email",
+      "open"
+    ]
+  },
+  "mail-reply": {
+    "keywords": [
+      "email"
+    ]
+  },
+  "mark-github": {
+    "keywords": [
+      "octocat"
+    ]
+  },
+  "markdown": {
+    "keywords": [
+      "markup",
+      "style"
+    ]
+  },
+  "megaphone": {
+    "keywords": [
+      "bullhorn",
+      "loud",
+      "shout",
+      "broadcast"
+    ]
+  },
+  "mention": {
+    "keywords": [
+      "at",
+      "ping"
+    ]
+  },
+  "milestone": {
+    "keywords": [
+      "marker"
+    ]
+  },
+  "mirror": {
+    "keywords": [
+      "reflect"
+    ]
+  },
+  "mortar-board": {
+    "keywords": [
+      ""
+    ]
+  },
+  "mute": {
+    "keywords": [
+      "quiet",
+      "sound",
+      "audio",
+      "turn",
+      "off"
+    ]
+  },
+  "no-newline": {
+    "keywords": [
+      "return"
+    ]
+  },
+  "octoface": {
+    "keywords": [
+      "octocat"
+    ]
+  },
+  "organization": {
+    "keywords": [
+      "people",
+      "group",
+      "team"
+    ]
+  },
+  "package": {
+    "keywords": [
+      "box",
+      "ship"
+    ]
+  },
+  "paintcan": {
+    "keywords": [
+      "style",
+      "theme",
+      "art",
+      "color"
+    ]
+  },
+  "pencil": {
+    "keywords": [
+      "edit",
+      "change",
+      "update",
+      "write"
+    ]
+  },
+  "person": {
+    "keywords": [
+      "people",
+      "man",
+      "woman",
+      "human"
+    ]
+  },
+  "pin": {
+    "keywords": [
+      "people",
+      "save",
+      "star",
+      "bookmark"
+    ]
+  },
+  "plug": {
+    "keywords": [
+      "hook",
+      "webhook"
+    ]
+  },
+  "plus": {
+    "keywords": [
+      "add",
+      "new",
+      "more"
+    ]
+  },
+  "plus-small": {
+    "keywords": [
+      "add",
+      "new",
+      "more",
+      "small"
+    ]
+  },
+  "primitive-dot": {
+    "keywords": [
+      "circle"
+    ]
+  },
+  "primitive-square": {
+    "keywords": [
+      "box"
+    ]
+  },
+  "pulse": {
+    "keywords": [
+      "graph",
+      "trend",
+      "line"
+    ]
+  },
+  "question": {
+    "keywords": [
+      "help",
+      "explain"
+    ]
+  },
+  "quote": {
+    "keywords": [
+      "quotation"
+    ]
+  },
+  "radio-tower": {
+    "keywords": [
+      "broadcast"
+    ]
+  },
+  "repo": {
+    "keywords": [
+      "book",
+      "journal"
+    ]
+  },
+  "repo-clone": {
+    "keywords": [
+      "book",
+      "journal"
+    ]
+  },
+  "repo-force-push": {
+    "keywords": [
+      "book",
+      "journal",
+      "put"
+    ]
+  },
+  "repo-forked": {
+    "keywords": [
+      "book",
+      "journal",
+      "copy"
+    ]
+  },
+  "repo-pull": {
+    "keywords": [
+      "book",
+      "journal",
+      "get"
+    ]
+  },
+  "repo-push": {
+    "keywords": [
+      "book",
+      "journal",
+      "put"
+    ]
+  },
+  "rocket": {
+    "keywords": [
+      "staff",
+      "stafftools",
+      "blast",
+      "off",
+      "space"
+    ]
+  },
+  "rss": {
+    "keywords": [
+      "broadcast",
+      "feed"
+    ]
+  },
+  "ruby": {
+    "keywords": [
+      "code"
+    ]
+  },
+  "search": {
+    "keywords": [
+      "magnifying",
+      "glass"
+    ]
+  },
+  "server": {
+    "keywords": [
+      "computers",
+      "racks",
+      "ops"
+    ]
+  },
+  "settings": {
+    "keywords": [
+      "sliders",
+      "filters"
+    ]
+  },
+  "shield": {
+    "keywords": [
+      "protect,",
+      "shield,",
+      "lock"
+    ]
+  },
+  "sign-in": {
+    "keywords": [
+      "door",
+      "arrow",
+      "direction",
+      "enter"
+    ]
+  },
+  "sign-out": {
+    "keywords": [
+      "door",
+      "arrow",
+      "direction",
+      "leave"
+    ]
+  },
+  "smiley": {
+    "keywords": [
+      "emoji",
+      "smile",
+      "mood",
+      "emotion"
+    ]
+  },
+  "squirrel": {
+    "keywords": [
+      "ship",
+      "shipit"
+    ]
+  },
+  "star": {
+    "keywords": [
+      "save",
+      "remember",
+      "like"
+    ]
+  },
+  "stop": {
+    "keywords": [
+      "block",
+      "spam"
+    ]
+  },
+  "sync": {
+    "keywords": [
+      "cycle",
+      "refresh",
+      "loop"
+    ]
+  },
+  "tag": {
+    "keywords": [
+      "release"
+    ]
+  },
+  "tasklist": {
+    "keywords": [
+      ""
+    ]
+  },
+  "telescope": {
+    "keywords": [
+      "science",
+      "space",
+      "look",
+      "view",
+      "explore"
+    ]
+  },
+  "terminal": {
+    "keywords": [
+      "code",
+      "ops",
+      "shell"
+    ]
+  },
+  "text-size": {
+    "keywords": [
+      ""
+    ]
+  },
+  "three-bars": {
+    "keywords": [
+      "hamburger"
+    ]
+  },
+  "thumbsdown": {
+    "keywords": [
+      "thumb",
+      "thumbsdown",
+      "rejected"
+    ]
+  },
+  "thumbsup": {
+    "keywords": [
+      "thumb",
+      "thumbsup",
+      "prop",
+      "ship"
+    ]
+  },
+  "tools": {
+    "keywords": [
+      "screwdriver",
+      "wrench",
+      "settings"
+    ]
+  },
+  "trashcan": {
+    "keywords": [
+      "garbage",
+      "rubbish",
+      "recycle",
+      "delete"
+    ]
+  },
+  "triangle-down": {
+    "keywords": [
+      "arrow",
+      "point",
+      "direction"
+    ]
+  },
+  "triangle-left": {
+    "keywords": [
+      "arrow",
+      "point",
+      "direction"
+    ]
+  },
+  "triangle-right": {
+    "keywords": [
+      "arrow",
+      "point",
+      "direction"
+    ]
+  },
+  "triangle-up": {
+    "keywords": [
+      "arrow",
+      "point",
+      "direction"
+    ]
+  },
+  "unfold": {
+    "keywords": [
+      "expand",
+      "open",
+      "reveal"
+    ]
+  },
+  "unmute": {
+    "keywords": [
+      "loud",
+      "volume",
+      "audio",
+      "sound",
+      "play"
+    ]
+  },
+  "unverified": {
+    "keywords": [
+      "insecure,",
+      "untrusted"
+    ]
+  },
+  "verified": {
+    "keywords": [
+      "trusted,",
+      "secure,",
+      "trustworthy"
+    ]
+  },
+  "versions": {
+    "keywords": [
+      "history"
+    ]
+  },
+  "watch": {
+    "keywords": [
+      "wait,",
+      "hourglass"
+    ]
+  },
+  "x": {
+    "keywords": [
+      "remove",
+      "close",
+      "delete"
+    ]
+  },
+  "zap": {
+    "keywords": [
+      "electricity",
+      "lightning",
+      "props",
+      "like",
+      "star",
+      "save"
+    ]
+  },
+  "ellipses": {
+    "keywords": [
+      "dot",
+      "more"
+    ]
+  },
+  "file": {
+    "keywords": [
+      "file"
+    ]
+  },
+  "grabber": {
+    "keywords": [
+      "mover",
+      "drap",
+      "drop"
+    ]
+  },
+  "reply": {
+    "keywords": [
+      "reply all",
+      "back"
+    ]
+  }
+}

--- a/lib/keywords.json
+++ b/lib/keywords.json
@@ -82,7 +82,7 @@
   },
   "bold": {
     "keywords": [
-      ""
+      "bold"
     ]
   },
   "book": {
@@ -446,17 +446,21 @@
   },
   "gist": {
     "keywords": [
-      ""
+      "gist",
+      "github"
     ]
   },
   "gist-secret": {
     "keywords": [
-      ""
+      "gist",
+      "secret",
+      "private"
     ]
   },
   "git-branch": {
     "keywords": [
-      ""
+      "branch",
+      "git"
     ]
   },
   "git-commit": {
@@ -554,7 +558,9 @@
   },
   "italic": {
     "keywords": [
-      ""
+      "font",
+      "italic",
+      "style"
     ]
   },
   "jersey": {
@@ -582,7 +588,8 @@
   },
   "law": {
     "keywords": [
-      ""
+      "legal",
+      "bill"
     ]
   },
   "light-bulb": {
@@ -637,7 +644,8 @@
   },
   "logo-gist": {
     "keywords": [
-      ""
+      "logo",
+      "gist"
     ]
   },
   "logo-github": {
@@ -699,7 +707,9 @@
   },
   "mortar-board": {
     "keywords": [
-      ""
+      "education",
+      "learn",
+      "teach"
     ]
   },
   "mute": {
@@ -901,8 +911,8 @@
   },
   "shield": {
     "keywords": [
-      "protect,",
-      "shield,",
+      "protect",
+      "shield",
       "lock"
     ]
   },
@@ -963,7 +973,7 @@
   },
   "tasklist": {
     "keywords": [
-      ""
+      "todo"
     ]
   },
   "telescope": {
@@ -984,7 +994,9 @@
   },
   "text-size": {
     "keywords": [
-      ""
+      "font",
+      "size",
+      "text"
     ]
   },
   "three-bars": {
@@ -1068,14 +1080,14 @@
   },
   "unverified": {
     "keywords": [
-      "insecure,",
+      "insecure",
       "untrusted"
     ]
   },
   "verified": {
     "keywords": [
-      "trusted,",
-      "secure,",
+      "trusted",
+      "secure",
       "trustworthy"
     ]
   },
@@ -1086,7 +1098,7 @@
   },
   "watch": {
     "keywords": [
-      "wait,",
+      "wait",
       "hourglass"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "author": "GitHub Inc.",
   "license": "(OFL-1.1 OR MIT)",
   "style": "index.scss",
+  "main": "index.js",
   "files": [
     "index.scss",
+    "index.js",
     "lib",
     "build"
   ],
@@ -18,10 +20,11 @@
   "scripts": {
     "setup": "script/bootstrap",
     "build": "npm run setup && grunt",
-    "test": ""
+    "test": "ava --verbose \"test/**/*.js\""
   },
   "devDependencies": {
     "autoprefixer": "^6.3.6",
+    "ava": "^0.15.2",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.7.0",
     "grunt-cssnano": "^2.1.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,29 @@
+import test from 'ava';
+import octicons from '../';
+import fs from 'fs';
+
+const octiconsLib = fs.readdirSync("../lib/svg/");
+
+test('octicon keywords and codepoints are loaded', t => {
+  t.truthy(octicons, "Didn't find any octicons.");
+  t.not(octicons.keywords.length, 0, "Didn't find any keywords.")
+  t.not(octicons.codepoints.length, 0, "Didn't find any codepoints.")
+});
+
+octiconsLib.forEach( point => {
+  point = point.replace('.svg', '');
+
+  ['keywords', 'codepoints'].forEach( filename => {
+    test(filename + '.json contains `' + point + '`', t => {
+      t.truthy(octicons[filename][point], 'Can\'t find the `' + point + '` octicon in ' + filename + '.json');
+    });
+  });
+});
+
+['keywords', 'codepoints'].forEach( filename => {
+  Object.keys(octicons[filename]).forEach( point => {
+    test(filename + '.json has the valid octicon `' + point + '`', t => {
+      t.truthy(octiconsLib.indexOf(point+'.svg') >= 0, filename + '.json contains the deleted octicon `' + point + '`, please remove it.' );
+    });
+  });
+});


### PR DESCRIPTION
I wanted to create a map of octicons that had a list of octicons and keywords. I'm going to be using this on the octicons.github.com website to generate the pages. But this can be useful for other things:

- creating fuzzy searches of the icons
- having a list of all the icons

The way it works is, you can do this in node.js now:

```js
var octicons = require("octicons");
console.log(octicons.keywords.alert);
// output -> {
//    "keywords": [
//      "warning",
//      "triangle",
//      "exclamation",
//      "point"
//    ]
//  }
```

I also wrote some tests to make sure that we always have a keyword and **codepoint** for every svg file. It also complains when we remove svg/icons and they haven't been removed from `keywords.json` or `codepoints.json`

-
@aaronshekey 