### PR TITLE
Stop using sass as a dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,30 +7,8 @@ module.exports = function(grunt) {
 
     pkg: grunt.file.readJSON('package.json'),
 
-    sass: {
-      options: {
-      },
-      dist: {
-        files: {
-          'build/octicons.css': 'index.scss'
-        }
-      }
-    },
-
-    postcss: {
-      options: {
-        processors: [
-          require('autoprefixer')({ browsers: '> 5%' })
-        ]
-      },
-      build: {
-        src: 'build/**/*.*css'
-      }
-    },
-
     cssnano: {
-      options: {
-      },
+      options: {},
       dist: {
         files: {
           'build/octicons.min.css': 'build/octicons.css'
@@ -81,24 +59,28 @@ module.exports = function(grunt) {
     },
 
     clean: {
-      svg: [
-        'build/svg/*',
-        'build/sprite.octicons.svg',
-        'build/octicons.*'
+      build: [
+        'build/*'
       ]
+    },
+
+    copy: {
+      css: {
+        src: "lib/octicons.css",
+        dest: "build/octicons.css"
+      }
     }
   });
 
   grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-postcss');
+  grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-svg-sprite');
   grunt.loadNpmTasks('grunt-svgmin');
   grunt.loadNpmTasks('grunt-cssnano');
-  grunt.loadNpmTasks('grunt-sass');
 
   // build tasks
-  grunt.registerTask('css',  ['sass', 'postcss', 'cssnano']);
-  grunt.registerTask('svg', ['clean:svg', 'svgmin', 'svg_sprite']);
+  grunt.registerTask('css',  ['copy', 'cssnano']);
+  grunt.registerTask('svg', ['clean', 'svgmin', 'svg_sprite']);
 
   // default task, build /dist/
   grunt.registerTask('default', [ 'svg', 'css', 'svg_json']);

--- a/index.scss
+++ b/index.scss
@@ -1,1 +1,0 @@
-@import "./lib/octicons.scss";

--- a/lib/octicons.css
+++ b/lib/octicons.css
@@ -1,0 +1,5 @@
+.octicon {
+  display: inline-block;
+  vertical-align: text-top;
+  fill: currentColor;
+}

--- a/lib/octicons.scss
+++ b/lib/octicons.scss
@@ -1,6 +1,0 @@
-// SVG icons
-.octicon {
-  display: inline-block;
-  vertical-align: text-top;
-  fill: currentColor;
-}

--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
   "homepage": "https://octicons.github.com",
   "author": "GitHub Inc.",
   "license": "(OFL-1.1 OR MIT)",
-  "style": "index.scss",
+  "style": "build/octicons.css",
   "main": "index.js",
   "files": [
-    "index.scss",
     "index.js",
     "lib",
     "build"
@@ -27,9 +26,8 @@
     "ava": "^0.16.0",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-cssnano": "^2.1.0",
-    "grunt-postcss": "^0.8.0",
-    "grunt-sass": "^1.2.0",
     "grunt-svg-sprite": "^1.2.19",
     "grunt-svgmin": "^3.2.0"
   },


### PR DESCRIPTION
With the deprecation of the font #117 we barely use sass. Our css file is 3 lines with no funny sass stuff.

So I'm removing the dependency on the scss file and using Good old CSS. The compiled file ends up in `/build/octicons.css` just like before.

We also had autoprefixer in the mix, for any prefixes we might need, but we're using css that doesn't require prefixes so killing that also.