### PR TITLE
Leaving fill-rule on minimized SVG elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 build
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### HEAD
 
+### 5.0.1
+
+Fixes:
+
+- projects icon renders as a block, using `fill-rule` fixes it
+
 ### 5.0.0
 
 Adds:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
           plugins: [
             {removeTitle: true},
             {removeStyleElement: true},
-            {removeAttrs: { attrs: ['id', 'class', 'data-name', 'fill', 'fill-rule'] }},
+            {removeAttrs: { attrs: ['id', 'class', 'data-name', 'fill'] }},
             {removeEmptyContainers: true},
             {sortAttrs: true},
             {removeUselessDefs: true},


### PR DESCRIPTION
fixes https://github.com/primer/octicons/issues/138

Removing the `fill-rule` attribute will make the projects icon become a block. Leaving it on properly renders it. The file size is slightly larger, but until we can do an audit and redesign our icons, we'll need to have this to make it work.