### PR TITLE
Update README sentence with toSVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ octicons.alert
 //   toSVG: [Function] }
 ```
 
-There will be a key for every icon, with `keywords` and `svg`.
+There will be a key for every icon, with [`toSVG`](#octiconsalerttosvg) and other properties.
 
 #### `octicons.alert.symbol`
 


### PR DESCRIPTION
I replaced the specific mention of `keywords`, because I'm guessing it was one of only a few properties

Fixes #143 