### PR TITLE
Replace ES6 Object.assign method with polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 var data = require('./build/data.json')
+var objectAssign = require('object-assign')
 
 Object.keys(data).forEach(function(key) {
 
   // Returns a string representation of html attributes
   var htmlAttributes = function(icon, options) {
     var attributes = []
-    var attrObj = Object.assign({}, data[key].options, options)
+    var attrObj = objectAssign({}, data[key].options, options)
 
     // If the user passed in options
     if (options) {

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "icons",
     "svg",
     "octicons"
-  ]
+  ],
+  "dependencies": {
+    "object-assign": "^4.1.1"
+  }
 }


### PR DESCRIPTION
[Object.assign](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) is an ES6 method and is not supported on older browsers such as Internet Explorer and the Android mobile browser. This PR adds a [commonly-used module](https://dependency.land/object-assign/*) for a polyfill to fall back on if the user is using an older browser. If the user has an evergreen browser the native Object.assign method is used.