### PR TITLE
Preparing 6.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ### HEAD
 
+### 6.0.0
+
+Added:
+
+- `kebab-horizontal` and `kebab-vertical` icons
+
 Removes:
 
-- Removing a duplicate ellipsis icon from
+- Removing a duplicate `ellipses` icon from the set. Use `ellipsis` instead.
 
 ### 5.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Added:
 
 - `kebab-horizontal` and `kebab-vertical` icons
+- Polyfill for the `Object.assign` function
 
 Removes:
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.1",
+  "version": "6.0.0",
   "name": "octicons",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",


### PR DESCRIPTION
This prepares the `6.0.0` release of octicons and updates the Changelog.

The updates going in are 

- #169 
- #164 
- #163 

#164 removes one of the octicon name spaces "ellipses" so I'm calling this a breaking change because people relying on the removed name will get errors.