### PR TITLE
Simplify kebab markup

### DIFF
--- a/lib/svg/kebab-horizontal.svg
+++ b/lib/svg/kebab-horizontal.svg
@@ -1,12 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="13px" height="16px" viewBox="0 0 13 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 46 (44423) - http://www.bohemiancoding.com/sketch -->
-    <title>kebab-horizontal</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Octicons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="kebab-horizontal" fill="#000000">
-            <path d="M1.5,9 C0.671572875,9 0,8.32842712 0,7.5 C0,6.67157288 0.671572875,6 1.5,6 C2.32842712,6 3,6.67157288 3,7.5 C3,8.32842712 2.32842712,9 1.5,9 Z M6.5,9 C5.67157288,9 5,8.32842712 5,7.5 C5,6.67157288 5.67157288,6 6.5,6 C7.32842712,6 8,6.67157288 8,7.5 C8,8.32842712 7.32842712,9 6.5,9 Z M11.5,9 C10.6715729,9 10,8.32842712 10,7.5 C10,6.67157288 10.6715729,6 11.5,6 C12.3284271,6 13,6.67157288 13,7.5 C13,8.32842712 12.3284271,9 11.5,9 Z" id="Shape"></path>
-        </g>
-    </g>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 13 16" style="enable-background:new 0 0 13 16;" xml:space="preserve">
+  <circle cx="1.5" cy="7.5" r="1.5"/>
+  <circle cx="6.5" cy="7.5" r="1.5"/>
+  <circle cx="11.5" cy="7.5" r="1.5"/>
 </svg>

--- a/lib/svg/kebab-horizontal.svg
+++ b/lib/svg/kebab-horizontal.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 13 16" style="enable-background:new 0 0 13 16;" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 13 16" xml:space="preserve">
   <circle cx="1.5" cy="7.5" r="1.5"/>
   <circle cx="6.5" cy="7.5" r="1.5"/>
   <circle cx="11.5" cy="7.5" r="1.5"/>

--- a/lib/svg/kebab-horizontal.svg
+++ b/lib/svg/kebab-horizontal.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 13 16" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 13 16">
   <circle cx="1.5" cy="7.5" r="1.5"/>
   <circle cx="6.5" cy="7.5" r="1.5"/>
   <circle cx="11.5" cy="7.5" r="1.5"/>

--- a/lib/svg/kebab-vertical.svg
+++ b/lib/svg/kebab-vertical.svg
@@ -1,12 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="3px" height="16px" viewBox="0 0 3 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 46 (44423) - http://www.bohemiancoding.com/sketch -->
-    <title>kebab-vertical</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Octicons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="kebab-vertical" fill="#000000">
-            <path d="M-4.4408921e-16,2.5 C0,1.67157288 0.671572875,1 1.5,1 C2.32842712,1 3,1.67157288 3,2.5 C3,3.32842712 2.32842712,4 1.5,4 C0.671572875,4 -4.4408921e-16,3.32842712 -4.4408921e-16,2.5 Z M-4.4408921e-16,7.5 C0,6.67157288 0.671572875,6 1.5,6 C2.32842712,6 3,6.67157288 3,7.5 C3,8.32842712 2.32842712,9 1.5,9 C0.671572875,9 -4.4408921e-16,8.32842712 -4.4408921e-16,7.5 Z M-4.4408921e-16,12.5 C0,11.6715729 0.671572875,11 1.5,11 C2.32842712,11 3,11.6715729 3,12.5 C3,13.3284271 2.32842712,14 1.5,14 C0.671572875,14 -4.4408921e-16,13.3284271 -4.4408921e-16,12.5 Z" id="Shape"></path>
-        </g>
-    </g>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 3 16" style="enable-background:new 0 0 3 16;" xml:space="preserve">
+  <circle cx="1.5" cy="2.5" r="1.5"/>
+  <circle cx="1.5" cy="7.5" r="1.5"/>
+  <circle cx="1.5" cy="12.5" r="1.5"/>
 </svg>

--- a/lib/svg/kebab-vertical.svg
+++ b/lib/svg/kebab-vertical.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 3 16" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 3 16">
   <circle cx="1.5" cy="2.5" r="1.5"/>
   <circle cx="1.5" cy="7.5" r="1.5"/>
   <circle cx="1.5" cy="12.5" r="1.5"/>

--- a/lib/svg/kebab-vertical.svg
+++ b/lib/svg/kebab-vertical.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 3 16" style="enable-background:new 0 0 3 16;" xml:space="preserve">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 3 16" xml:space="preserve">
   <circle cx="1.5" cy="2.5" r="1.5"/>
   <circle cx="1.5" cy="7.5" r="1.5"/>
   <circle cx="1.5" cy="12.5" r="1.5"/>


### PR DESCRIPTION
This PR simplifies the SVG markup for the kebab icons added in #169.

I opened these in Illustrator (originally exported from Sketch) and simplified the paths (released the compound path to use just individual circle elements). Saving from Illustrator added some extra markup that I deleted, and a couple things I'm not sure if is helpful to keep or not:
- ~~`style="enable-background:new 0 0 3 16;"`~~
- ~~`xml:space="preserve"`~~

_Edit: both of these xml attributes are unnecessary in this use case_

cc @jonrohan @broccolini 