### PR TITLE
Changing the GitHub logo red

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "release": "script/clean && script/export && $(npm bin)/lerna publish --exact --since \"v$(npm info octicons version)\""
   },
   "figma": {
-    "url": "https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons"
+    "url": "https://www.figma.com/file/bvk9lSbyES5QsUPBT2lrf1/Octicons-(Jon's-Changes)"
   },
   "devDependencies": {
     "ava": "^0.22.0",


### PR DESCRIPTION
I made some design changes to the octicons, changing GitHub's logo to red 😎 

| Before | After |
| :-- | :-- |
| ![logo-github 2x](https://user-images.githubusercontent.com/54012/37810976-7406a64e-2e14-11e8-9b32-2daae5269b53.png) | ![logo-github 2x](https://user-images.githubusercontent.com/54012/37810978-775006a6-2e14-11e8-81fe-b4e3a36fcf8c.png) |

