### PR TITLE
Updating CONTRIBUTING.md instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,1 +1,44 @@
 # Icons
+
+## Contributing
+
+1. **Duplicate:** The first step is to make a copy of the [master Octicons file][master-octicons] to your drafts folder. You can do this from the dropdown menu, select "Duplicate to your drafts".
+
+   [<img src="https://user-images.githubusercontent.com/54012/37802948-c10dca06-2de9-11e8-98c3-dd45cd561865.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37802948-c10dca06-2de9-11e8-98c3-dd45cd561865.gif)
+
+2. **Edit:** In your duplicate file, make proposed changes. In the example, we’ll change the logo red.
+
+   [<img src="https://user-images.githubusercontent.com/54012/37803022-14d1a0fe-2dea-11e8-862d-b7ef22c918cf.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37803022-14d1a0fe-2dea-11e8-862d-b7ef22c918cf.gif)
+
+3. **Share:** Make sure your duplicate file can be viewed by others. In the share menu "Anyone with link" should be set to "can view". It will also simplify things if you give your file a unique name ie _Octicons (Jon’s Changes)_.
+
+   [<img src="https://user-images.githubusercontent.com/54012/37803059-3ca54432-2dea-11e8-8c27-36c83a2dc5cb.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37803059-3ca54432-2dea-11e8-8c27-36c83a2dc5cb.gif)
+
+4. **(Optional) Pull Request:** Submit a Pull Request with your updated file in the `figma.url` field of the `package.json`. This will generate an alpha release of the icons with your set. For testing.
+
+   ```js
+   "figma": {
+     "url": "https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons"
+   }
+   ```
+
+   ![image](https://user-images.githubusercontent.com/54012/37808540-1448e160-2e08-11e8-8a16-cbd94e4da2e0.png)
+
+
+---
+
+## Maintainers
+
+1. Publish changed Octicon to team library.
+
+   [<img src="https://user-images.githubusercontent.com/54012/37807772-6734f926-2e04-11e8-98a0-9b4c73411bd3.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807772-6734f926-2e04-11e8-98a0-9b4c73411bd3.gif)
+
+2. Import changed Octicon into master Octicons file.
+
+   [<img src="https://user-images.githubusercontent.com/54012/37807775-6b1dea52-2e04-11e8-804a-a41c6bc04fd2.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807775-6b1dea52-2e04-11e8-804a-a41c6bc04fd2.gif)
+
+3. Replace old Octicon with updated Octicon.
+
+   [<img src="https://user-images.githubusercontent.com/54012/37807780-6ddba626-2e04-11e8-9a6b-749ac5b800fe.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807780-6ddba626-2e04-11e8-9a6b-749ac5b800fe.gif)
+
+[master-octicons]: https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,31 +36,45 @@ Once the build passes on your pull request, you should see statuses with all the
 
 # Maintainers accepting changes
 
+Once submitted changes have been agreed upon, these instructions will guide core Primer team members in merging in those changes.
+
 ## Step 1, Save:
+
+Save the contributor’s figma file as a `.fig` file.
 
 [<img src="https://user-images.githubusercontent.com/54012/37809888-940f5d38-2e0e-11e8-957f-99c162a1d4ff.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37809888-940f5d38-2e0e-11e8-957f-99c162a1d4ff.gif)
 
 ## Step 2, Import:
+
+Drag and drop, or add the file to the main team project. Make sure it’s name is different from the master Octicons file.
 
 [<img src="https://user-images.githubusercontent.com/54012/37809879-8d9824ee-2e0e-11e8-9b1d-e83316192eb0.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37809879-8d9824ee-2e0e-11e8-9b1d-e83316192eb0.gif)
 
 
 ## Step 3, Publish:
 
-Publish changed Octicon to team library.
+From the new imported file, publish the updated or new components to the team library. This published component makes importing into the master document easier.
 
 [<img src="https://user-images.githubusercontent.com/54012/37807772-6734f926-2e04-11e8-98a0-9b4c73411bd3.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807772-6734f926-2e04-11e8-98a0-9b4c73411bd3.gif)
 
 ## Step 4, Add:
 
-Import changed Octicon into master Octicons file.
+In the Team Library you will see the new Octicons file, and all the components from that file. Add the new components to the master Octicons file. It makes changing easier if you drag it on top of the icon you are changing.
 
 [<img src="https://user-images.githubusercontent.com/54012/37807775-6b1dea52-2e04-11e8-804a-a41c6bc04fd2.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807775-6b1dea52-2e04-11e8-804a-a41c6bc04fd2.gif)
 
 ## Step 5, Replace:
 
-Replace old Octicon with updated Octicon.
+Right click on the new component instance and select "Detach Instance". Then toggle both the old and new components open. Move the shape from the new component into the old component. Delete the old component’s shape. Delete the empty new component container.
 
 [<img src="https://user-images.githubusercontent.com/54012/37807780-6ddba626-2e04-11e8-9a6b-749ac5b800fe.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807780-6ddba626-2e04-11e8-9a6b-749ac5b800fe.gif)
+
+## Step 6, Publishing:
+
+Publish the component changes to your team library. You can now delete the imported `.fig` file from the contributor.
+
+[<img src="https://user-images.githubusercontent.com/54012/37812350-cc2349ba-2e1c-11e8-8b80-d9ff2f8d4ea3.png" width="600"/>](https://user-images.githubusercontent.com/54012/37812350-cc2349ba-2e1c-11e8-8b80-d9ff2f8d4ea3.png)
+
+In this repository run the script `npm run bump` to bump the library versions. Commit the version number changes to a new pull request.
 
 [master-octicons]: https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,16 +36,31 @@ Submit a Pull Request with your updated file in the `figma.url` field of the `pa
 
 ## Maintainers
 
-1. Publish changed Octicon to team library.
+### Step 1, Save:
 
-   [<img src="https://user-images.githubusercontent.com/54012/37807772-6734f926-2e04-11e8-98a0-9b4c73411bd3.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807772-6734f926-2e04-11e8-98a0-9b4c73411bd3.gif)
+[<img src="https://user-images.githubusercontent.com/54012/37809888-940f5d38-2e0e-11e8-957f-99c162a1d4ff.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37809888-940f5d38-2e0e-11e8-957f-99c162a1d4ff.gif)
 
-2. Import changed Octicon into master Octicons file.
+### Step 2, Import:
 
-   [<img src="https://user-images.githubusercontent.com/54012/37807775-6b1dea52-2e04-11e8-804a-a41c6bc04fd2.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807775-6b1dea52-2e04-11e8-804a-a41c6bc04fd2.gif)
+[<img src="https://user-images.githubusercontent.com/54012/37809879-8d9824ee-2e0e-11e8-9b1d-e83316192eb0.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37809879-8d9824ee-2e0e-11e8-9b1d-e83316192eb0.gif)
 
-3. Replace old Octicon with updated Octicon.
 
-   [<img src="https://user-images.githubusercontent.com/54012/37807780-6ddba626-2e04-11e8-9a6b-749ac5b800fe.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807780-6ddba626-2e04-11e8-9a6b-749ac5b800fe.gif)
+### Step 3, Publish:
+
+Publish changed Octicon to team library.
+
+[<img src="https://user-images.githubusercontent.com/54012/37807772-6734f926-2e04-11e8-98a0-9b4c73411bd3.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807772-6734f926-2e04-11e8-98a0-9b4c73411bd3.gif)
+
+### Step 4, Add:
+
+Import changed Octicon into master Octicons file.
+
+[<img src="https://user-images.githubusercontent.com/54012/37807775-6b1dea52-2e04-11e8-804a-a41c6bc04fd2.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807775-6b1dea52-2e04-11e8-804a-a41c6bc04fd2.gif)
+
+### Step 5, Replace:
+
+Replace old Octicon with updated Octicon.
+
+[<img src="https://user-images.githubusercontent.com/54012/37807780-6ddba626-2e04-11e8-9a6b-749ac5b800fe.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807780-6ddba626-2e04-11e8-9a6b-749ac5b800fe.gif)
 
 [master-octicons]: https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Adding or Updating icons
 
-If you plan to update an icon and/or add a new icon follow these steps. These steps will be the same; If you are a core Primer team member, or a contributor wanting to try something new.
+If you plan to update an icon and/or add a new icon follow these steps. These steps will be the same for core primer members and contributors.
 
-Complete steps [1](#step-1-duplicate) - [3](#step-3-share) and notify us of your changes, either with [a pull request](#step-4-pull-request-optional) or [an  issue](https://github.com/primer/octicons/issues/new) describing your changes. Screen shots welcome! 🎉
+Complete steps 1 - 3 and notify us of your changes, either with a pull request or an issue describing your changes. Screen shots welcome! 🎉
 
 ## Step 1, Duplicate:
 
@@ -12,19 +12,19 @@ The first step is to make a copy of the [master Octicons file][master-octicons] 
 
 ## Step 2, Edit:
 
-In your duplicate file, make proposed changes. In the example, we’ll change the logo red.
+In your duplicate file, make proposed changes. In the example, we’ll change the logo red. It will also simplify things if you give your file a unique name ie _Octicons (Jon’s Changes)_.
 
 [<img src="https://user-images.githubusercontent.com/54012/37803022-14d1a0fe-2dea-11e8-862d-b7ef22c918cf.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37803022-14d1a0fe-2dea-11e8-862d-b7ef22c918cf.gif)
 
 ## Step 3, Share:
 
-Make sure your duplicate file can be viewed by others. In the share menu "Anyone with link" should be set to "can view". Copy the link. It will also simplify things if you give your file a unique name ie _Octicons (Jon’s Changes)_.
+Make sure your duplicate file can be viewed by others. In the share menu "Anyone with link" should be set to "can view". Copy the link.
 
 [<img src="https://user-images.githubusercontent.com/54012/37803059-3ca54432-2dea-11e8-8c27-36c83a2dc5cb.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37803059-3ca54432-2dea-11e8-8c27-36c83a2dc5cb.gif)
 
 ## Step 4, Pull Request: _(Optional)_
 
-You can submit a pull request with the url of your updated file. Doing so will generate alpha releases of [all the libraries that distribute Octicons](https://github.com/primer/octicons#libraries). Change the figma url configuration in the root [package.json](https://github.com/primer/octicons/blob/master/package.json#L10) file of this repository.
+You can submit a pull request updating the `figma.url` configuration in the root [package.json](https://github.com/primer/octicons/blob/master/package.json#L10) with your figma file. Doing so will generate alpha releases of [all the libraries that distribute Octicons](https://github.com/primer/octicons#libraries).
 
 Once the build passes on your pull request, you should see statuses with all the alpha versions of the libraries. You can then use these to test your changes.
 
@@ -36,7 +36,7 @@ Once the build passes on your pull request, you should see statuses with all the
 
 # Maintainers accepting changes
 
-Once submitted changes have been agreed upon, these instructions will guide core Primer team members in merging in those changes.
+Once submitted changes have been agreed upon, these instructions will guide core primer team members in merging in those changes.
 
 ## Step 1, Save:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,28 +2,35 @@
 
 ## Contributing
 
-1. **Duplicate:** The first step is to make a copy of the [master Octicons file][master-octicons] to your drafts folder. You can do this from the dropdown menu, select "Duplicate to your drafts".
+### Step 1, Duplicate:
 
-   [<img src="https://user-images.githubusercontent.com/54012/37802948-c10dca06-2de9-11e8-98c3-dd45cd561865.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37802948-c10dca06-2de9-11e8-98c3-dd45cd561865.gif)
+The first step is to make a copy of the [master Octicons file][master-octicons] to your drafts folder. You can do this from the dropdown menu, select "Duplicate to your drafts".
 
-2. **Edit:** In your duplicate file, make proposed changes. In the example, we’ll change the logo red.
+[<img src="https://user-images.githubusercontent.com/54012/37802948-c10dca06-2de9-11e8-98c3-dd45cd561865.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37802948-c10dca06-2de9-11e8-98c3-dd45cd561865.gif)
 
-   [<img src="https://user-images.githubusercontent.com/54012/37803022-14d1a0fe-2dea-11e8-862d-b7ef22c918cf.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37803022-14d1a0fe-2dea-11e8-862d-b7ef22c918cf.gif)
+### Step 2, Edit:
 
-3. **Share:** Make sure your duplicate file can be viewed by others. In the share menu "Anyone with link" should be set to "can view". It will also simplify things if you give your file a unique name ie _Octicons (Jon’s Changes)_.
+In your duplicate file, make proposed changes. In the example, we’ll change the logo red.
 
-   [<img src="https://user-images.githubusercontent.com/54012/37803059-3ca54432-2dea-11e8-8c27-36c83a2dc5cb.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37803059-3ca54432-2dea-11e8-8c27-36c83a2dc5cb.gif)
+[<img src="https://user-images.githubusercontent.com/54012/37803022-14d1a0fe-2dea-11e8-862d-b7ef22c918cf.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37803022-14d1a0fe-2dea-11e8-862d-b7ef22c918cf.gif)
 
-4. **(Optional) Pull Request:** Submit a Pull Request with your updated file in the `figma.url` field of the `package.json`. This will generate an alpha release of the icons with your set. For testing.
+### Step 3, Share:
 
-   ```js
-   "figma": {
-     "url": "https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons"
-   }
-   ```
+Make sure your duplicate file can be viewed by others. In the share menu "Anyone with link" should be set to "can view". Copy the link. It will also simplify things if you give your file a unique name ie _Octicons (Jon’s Changes)_.
 
-   ![image](https://user-images.githubusercontent.com/54012/37808540-1448e160-2e08-11e8-8a16-cbd94e4da2e0.png)
+[<img src="https://user-images.githubusercontent.com/54012/37803059-3ca54432-2dea-11e8-8c27-36c83a2dc5cb.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37803059-3ca54432-2dea-11e8-8c27-36c83a2dc5cb.gif)
 
+### Step 4, Pull Request: _(Optional)_
+
+Submit a Pull Request with your updated file in the `figma.url` field of the `package.json`. This will generate an alpha release of the icons with your set. For testing.
+
+```js
+"figma": {
+ "url": "https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons"
+}
+```
+
+![image](https://user-images.githubusercontent.com/54012/37808540-1448e160-2e08-11e8-8a16-cbd94e4da2e0.png)
 
 ---
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,30 +1,28 @@
-# Icons
-
-## Adding or Updating
+# Adding or Updating icons
 
 If you plan to update an icon and/or add a new icon follow these steps. These steps will be the same; If you are a core Primer team member, or a contributor wanting to try something new.
 
 Complete steps [1](#step-1-duplicate) - [3](#step-3-share) and notify us of your changes, either with [a pull request](#step-4-pull-request-optional) or [an  issue](https://github.com/primer/octicons/issues/new) describing your changes. Screen shots welcome! 🎉
 
-### Step 1, Duplicate:
+## Step 1, Duplicate:
 
 The first step is to make a copy of the [master Octicons file][master-octicons] to your drafts folder. You can do this from the dropdown menu, select "Duplicate to your drafts".
 
 [<img src="https://user-images.githubusercontent.com/54012/37802948-c10dca06-2de9-11e8-98c3-dd45cd561865.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37802948-c10dca06-2de9-11e8-98c3-dd45cd561865.gif)
 
-### Step 2, Edit:
+## Step 2, Edit:
 
 In your duplicate file, make proposed changes. In the example, we’ll change the logo red.
 
 [<img src="https://user-images.githubusercontent.com/54012/37803022-14d1a0fe-2dea-11e8-862d-b7ef22c918cf.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37803022-14d1a0fe-2dea-11e8-862d-b7ef22c918cf.gif)
 
-### Step 3, Share:
+## Step 3, Share:
 
 Make sure your duplicate file can be viewed by others. In the share menu "Anyone with link" should be set to "can view". Copy the link. It will also simplify things if you give your file a unique name ie _Octicons (Jon’s Changes)_.
 
 [<img src="https://user-images.githubusercontent.com/54012/37803059-3ca54432-2dea-11e8-8c27-36c83a2dc5cb.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37803059-3ca54432-2dea-11e8-8c27-36c83a2dc5cb.gif)
 
-### Step 4, Pull Request: _(Optional)_
+## Step 4, Pull Request: _(Optional)_
 
 You can submit a pull request with the url of your updated file. Doing so will generate alpha releases of [all the libraries that distribute Octicons](https://github.com/primer/octicons#libraries). Change the figma url configuration in the root [package.json](https://github.com/primer/octicons/blob/master/package.json#L10) file of this repository.
 
@@ -36,30 +34,30 @@ Once the build passes on your pull request, you should see statuses with all the
 
 ---
 
-## Maintainers
+# Maintainers accepting changes
 
-### Step 1, Save:
+## Step 1, Save:
 
 [<img src="https://user-images.githubusercontent.com/54012/37809888-940f5d38-2e0e-11e8-957f-99c162a1d4ff.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37809888-940f5d38-2e0e-11e8-957f-99c162a1d4ff.gif)
 
-### Step 2, Import:
+## Step 2, Import:
 
 [<img src="https://user-images.githubusercontent.com/54012/37809879-8d9824ee-2e0e-11e8-9b1d-e83316192eb0.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37809879-8d9824ee-2e0e-11e8-9b1d-e83316192eb0.gif)
 
 
-### Step 3, Publish:
+## Step 3, Publish:
 
 Publish changed Octicon to team library.
 
 [<img src="https://user-images.githubusercontent.com/54012/37807772-6734f926-2e04-11e8-98a0-9b4c73411bd3.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807772-6734f926-2e04-11e8-98a0-9b4c73411bd3.gif)
 
-### Step 4, Add:
+## Step 4, Add:
 
 Import changed Octicon into master Octicons file.
 
 [<img src="https://user-images.githubusercontent.com/54012/37807775-6b1dea52-2e04-11e8-804a-a41c6bc04fd2.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37807775-6b1dea52-2e04-11e8-804a-a41c6bc04fd2.gif)
 
-### Step 5, Replace:
+## Step 5, Replace:
 
 Replace old Octicon with updated Octicon.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,15 +22,13 @@ Make sure your duplicate file can be viewed by others. In the share menu "Anyone
 
 ### Step 4, Pull Request: _(Optional)_
 
-Submit a Pull Request with your updated file in the `figma.url` field of the `package.json`. This will generate an alpha release of the icons with your set. For testing.
+You can submit a pull request with the url of your updated file. Doing so will generate alpha releases of [all the libraries that distribute Octicons](https://github.com/primer/octicons#libraries). Change the figma url configuration in the root [package.json](https://github.com/primer/octicons/blob/master/package.json#L10) file of this repository.
 
-```js
-"figma": {
- "url": "https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons"
-}
-```
+Once the build passes on your pull request, you should see statuses with all the alpha versions of the libraries. You can then use these to test your changes.
 
-![image](https://user-images.githubusercontent.com/54012/37808540-1448e160-2e08-11e8-8a16-cbd94e4da2e0.png)
+[Here is an example pull request](https://github.com/primer/octicons/pull/206)
+
+[<img src="https://user-images.githubusercontent.com/54012/37811102-45ec2abc-2e15-11e8-8c1d-2d162ddcdad2.png" width="700"/>](https://user-images.githubusercontent.com/54012/37811102-45ec2abc-2e15-11e8-8c1d-2d162ddcdad2.png)
 
 ---
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,10 @@
 # Icons
 
-## Contributing
+## Adding or Updating
+
+If you plan to update an icon and/or add a new icon follow these steps. These steps will be the same; If you are a core Primer team member, or a contributor wanting to try something new.
+
+Complete steps [1](#step-1-duplicate) - [3](#step-3-share) and notify us of your changes, either with [a pull request](#step-4-pull-request-optional) or [an  issue](https://github.com/primer/octicons/issues/new) describing your changes. Screen shots welcome! 🎉
 
 ### Step 1, Duplicate:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 If you plan to update an icon and/or add a new icon follow these steps. These steps will be the same for core primer members and contributors.
 
-Complete steps 1 - 3 and notify us of your changes, either with a pull request or an issue describing your changes. Screen shots welcome! 🎉
+Complete steps 1 - 3 and notify us of your changes, either with a pull request or an issue describing your changes. Screenshots welcome! 🎉
 
 ## Step 1, Duplicate:
 
@@ -12,7 +12,7 @@ The first step is to make a copy of the [master Octicons file][master-octicons] 
 
 ## Step 2, Edit:
 
-In your duplicate file, make proposed changes. In the example, we’ll change the logo red. It will also simplify things if you give your file a unique name ie _Octicons (Jon’s Changes)_.
+In your duplicate file, make proposed changes. In the example, we’ll make the GitHub logo red. It will also simplify things if you give your file a unique name e.g. _Octicons (Jon’s Changes)_.
 
 [<img src="https://user-images.githubusercontent.com/54012/37803022-14d1a0fe-2dea-11e8-862d-b7ef22c918cf.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37803022-14d1a0fe-2dea-11e8-862d-b7ef22c918cf.gif)
 
@@ -46,7 +46,7 @@ Save the contributor’s figma file as a `.fig` file.
 
 ## Step 2, Import:
 
-Drag and drop, or add the file to the main team project. Make sure it’s name is different from the master Octicons file.
+Drag and drop, or add the file to the main team project. Make sure its name is different from the master Octicons file.
 
 [<img src="https://user-images.githubusercontent.com/54012/37809879-8d9824ee-2e0e-11e8-9b1d-e83316192eb0.gif" width="400"/>](https://user-images.githubusercontent.com/54012/37809879-8d9824ee-2e0e-11e8-9b1d-e83316192eb0.gif)
 
@@ -75,6 +75,6 @@ Publish the component changes to your team library. You can now delete the impor
 
 [<img src="https://user-images.githubusercontent.com/54012/37812350-cc2349ba-2e1c-11e8-8b80-d9ff2f8d4ea3.png" width="600"/>](https://user-images.githubusercontent.com/54012/37812350-cc2349ba-2e1c-11e8-8b80-d9ff2f8d4ea3.png)
 
-In this repository run the script `npm run bump` to bump the library versions. Commit the version number changes to a new pull request.
+Create a release branch, and run `npm run bump`. This will guide you through a prompt asking what all the new versions of the packages should be. After, push up your branch and open a pull request into master.
 
 [master-octicons]: https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Octicons are a set of SVG icons built by GitHub for GitHub. This repository is a
 
 ## Adding/Updating an icon
 
-Read through our [contributing guide](./.github/CONTRIBUTING.md#icons) if you're planning on adding or updating one of the icons.
+Read through our [contributing guide](./.github/CONTRIBUTING.md#adding-or-updating-icons) if you're planning on adding or updating one of the icons.
 
 ## Libraries
 


### PR DESCRIPTION
Closes #203
Closes #200
Closes #186 
Closes #180

This adds instructions for [contributors adding or updating icons](https://github.com/primer/octicons/blob/contributing/.github/CONTRIBUTING.md#adding-or-updating-icons), and instructions for [maintainers merging](https://github.com/primer/octicons/blob/contributing/.github/CONTRIBUTING.md#maintainers-accepting-changes) in contributions.

<kbd>[Rendered Version](https://github.com/primer/octicons/blob/contributing/.github/CONTRIBUTING.md)</kbd>