### PR TITLE
Changing the lerna version preference to locked

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,5 +6,5 @@
     "lib/octicons_helper",
     "lib/jekyll-octicons"
   ],
-  "version": "independent"
+  "version": "7.2.0"
 }


### PR DESCRIPTION
Closes #205 

This changes our versioning strategy to [**Fixed/Locked mode**](https://github.com/lerna/lerna#fixedlocked-mode-default).

