### PR TITLE
Release v8.0.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
     "lib/octicons_jekyll",
     "lib/octicons_react"
   ],
-  "version": "7.4.0"
+  "version": "8.0.0"
 }

--- a/lib/octicons_gem/lib/octicons/version.rb
+++ b/lib/octicons_gem/lib/octicons/version.rb
@@ -1,3 +1,3 @@
 module Octicons
-  VERSION = "7.4.0".freeze
+  VERSION = "8.0.0".freeze
 end

--- a/lib/octicons_gem/package.json
+++ b/lib/octicons_gem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octicons_gem",
-  "version": "7.4.0",
+  "version": "8.0.0",
   "description": "Don't install",
   "scripts": {
     "postinstall": "bundle install --path vendor/bundle",

--- a/lib/octicons_helper/lib/octicons_helper/version.rb
+++ b/lib/octicons_helper/lib/octicons_helper/version.rb
@@ -1,3 +1,3 @@
 module OcticonsHelper
-  VERSION = "7.4.0".freeze
+  VERSION = "8.0.0".freeze
 end

--- a/lib/octicons_helper/octicons_helper.gemspec
+++ b/lib/octicons_helper/octicons_helper.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "octicons", "7.4.0"
+  s.add_dependency "octicons", "8.0.0"
   s.add_dependency "rails"
 end

--- a/lib/octicons_helper/package.json
+++ b/lib/octicons_helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octicons_helper",
-  "version": "7.4.0",
+  "version": "8.0.0",
   "description": "A rails helper that makes including svg Octicons simple.",
   "scripts": {
     "version": "../../script/rubyversion ./lib/octicons_helper/version.rb",
@@ -21,6 +21,6 @@
   "rubygems": "octicons_helper",
   "homepage": "https://github.com/primer/octicons#readme",
   "dependencies": {
-    "octicons_gem": "7.4.0"
+    "octicons_gem": "8.0.0"
   }
 }

--- a/lib/octicons_jekyll/jekyll-octicons.gemspec
+++ b/lib/octicons_jekyll/jekyll-octicons.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "jekyll", "~> 3.1"
-  s.add_dependency "octicons", "7.4.0"
+  s.add_dependency "octicons", "8.0.0"
 end

--- a/lib/octicons_jekyll/lib/jekyll-octicons/version.rb
+++ b/lib/octicons_jekyll/lib/jekyll-octicons/version.rb
@@ -3,6 +3,6 @@ module Liquid; class Tag; end; end
 
 module Jekyll
   class Octicons < Liquid::Tag
-    VERSION = "7.4.0".freeze
+    VERSION = "8.0.0".freeze
   end
 end

--- a/lib/octicons_jekyll/package.json
+++ b/lib/octicons_jekyll/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jekyll-octicons",
-  "version": "7.4.0",
+  "version": "8.0.0",
   "description": "A jekyll liquid plugin that makes including svg Octicons simple.",
   "scripts": {
     "version": "../../script/rubyversion ./lib/jekyll-octicons/version.rb",
@@ -21,6 +21,6 @@
   "rubygems": "jekyll-octicons",
   "homepage": "https://github.com/primer/octicons#readme",
   "dependencies": {
-    "octicons_gem": "7.4.0"
+    "octicons_gem": "8.0.0"
   }
 }

--- a/lib/octicons_node/package.json
+++ b/lib/octicons_node/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.4.0",
+  "version": "8.0.0",
   "name": "octicons",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",

--- a/lib/octicons_react/README.md
+++ b/lib/octicons_react/README.md
@@ -1,6 +1,6 @@
 # [Octicons] for React
 
-[![npm version](https://img.shields.io/npm/v/%40github%2Focticons-react.svg)](https://www.npmjs.org/package/%40github%2Focticons-react)
+[![npm version](https://img.shields.io/npm/v/@githubprimer/octicons-react.svg)](https://www.npmjs.org/package/@githubprimer/octicons-react)
 [![Build Status](https://travis-ci.org/primer/octicons.svg?branch=master)](https://travis-ci.org/primer/octicons)
 
 ## Install

--- a/lib/octicons_react/README.md
+++ b/lib/octicons_react/README.md
@@ -1,14 +1,12 @@
-# GitHub Octicons React Component
+# [Octicons] for React
 
 [![npm version](https://img.shields.io/npm/v/%40github%2Focticons-react.svg)](https://www.npmjs.org/package/%40github%2Focticons-react)
 [![Build Status](https://travis-ci.org/primer/octicons.svg?branch=master)](https://travis-ci.org/primer/octicons)
 
-> [Octicons] for React
-
 ## Install
 
 ```
-$ npm install @github/octicons-react --save
+$ npm install @githubprimer/octicons-react --save
 ```
 
 ## Usage
@@ -34,7 +32,7 @@ Note that none of our builtin icons take props, so unless you're creating
 [custom icons](#custom-icons) you'll probably want to use the `icon` prop form.
 
 ### Icons
-The `@github/octicons-react` module exports the `Octicon` component as
+The `@githubprimer/octicons-react` module exports the `Octicon` component as
 `default` and the individual icon symbols as separate [named
 exports](https://ponyfoo.com/articles/es6-modules-in-depth#named-exports). This
 allows you to import only the icons that you need without blowing up your
@@ -42,7 +40,7 @@ bundle:
 
 ```jsx
 import React from 'react'
-import Octicon, {Beaker, Zap} from '@github/octicons-react'
+import Octicon, {Beaker, Zap} from '@githubprimer/octicons-react'
 
 export default function Icon({boom}) {
   return <Octicon icon={boom ? Zap : Beaker}/>
@@ -66,7 +64,7 @@ resolves it to the right component:
 
 ```jsx
 import React from 'react'
-import Octicon, {getIconByName} from '@github/octicons-react'
+import Octicon, {getIconByName} from '@githubprimer/octicons-react'
 
 export default function OcticonByName({name, ...props}) {
   return <Octicon {...props} icon={getIcon(name)} />
@@ -80,7 +78,7 @@ the octicons:
 
 ```jsx
 import React from 'react'
-import Octicon, {iconsByName} from '@github/octicons-react'
+import Octicon, {iconsByName} from '@githubprimer/octicons-react'
 
 export default function OcticonsList() {
   return (
@@ -102,7 +100,7 @@ styles. You can change the alignment via the `verticalAlign` prop, which can be
 either `middle`, `text-bottom`, `text-top`, or `top`.
 
 ```js
-import Octicon, {Repo} from '@github/octicons-react'
+import Octicon, {Repo} from '@githubprimer/octicons-react'
 
 export default () => (
   <h1>
@@ -119,7 +117,7 @@ capitalization of `L`!).
 
 ```js
 // Example usage
-import Octicon, {Plus} from '@github/octicons-react'
+import Octicon, {Plus} from '@githubprimer/octicons-react'
 
 export default () => (
   <button>
@@ -141,7 +139,7 @@ render octicons at standard sizes:
 
 ```js
 // Example usage
-import Octicon, {LogoGithub} from '@github/octicons-react'
+import Octicon, {LogoGithub} from '@githubprimer/octicons-react'
 
 export default () => (
   <h1>
@@ -162,7 +160,7 @@ custom icon that consisted of three circles side by side, you could do this:
 
 ```jsx
 import React from 'react'
-import Octicon from '@github/octicons-react'
+import Octicon from '@githubprimer/octicons-react'
 
 function CirclesIcon() {
   return (

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@github/octicons-react",
+  "name": "@githubprimer/octicons-react",
   "version": "8.0.0",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/octicons-react",
-  "version": "7.4.0",
+  "version": "8.0.0",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",
   "author": "GitHub, Inc.",

--- a/lib/octicons_react/pages/index.js
+++ b/lib/octicons_react/pages/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
-
-import Octicon, {iconsByName} from '../'
 import {Block, Text} from 'primer-react'
+import pkg from '../package.json'
+import Octicon, {iconsByName} from '../'
 
 export default function App() {
   const sizes = ['small', 'medium', 'large']
@@ -41,7 +41,7 @@ export default function App() {
                 <td>
                   <pre>
                     {`
-import Octicon, {${Icon.name}} from '@github/octicons-react'
+import Octicon, {${Icon.name}} from '${pkg.name}'
 export default () => <Octicon icon={${Icon.name}} />
                   `.trim()}
                   </pre>


### PR DESCRIPTION
This is a major version bump because we're changing the name of the [`@github/octicons-react` npm package](https://www.npmjs.com/package/@github/octicons-react) to `@githubprimer/octicons-react` (note that the new scope will be "github**primer**"). We will [deprecate](https://docs.npmjs.com/cli/deprecate) the `github`-scoped package as soon as the `githubprimer`-scoped one is published.

If you're using `@github/octicons-react` and don't want to see deprecation warnings every time you `npm install`, do this (once this PR is merged and the [release](https://github.com/primer/octicons/releases) is posted):

```
npm uninstall --save @github/octicons-react
npm install --save @githubprimer/octicons-react
```

Then find and replace each instance of the old package with the new one, e.g. with:

```sh
perl -pi -e 's#@github/octicons-react#@githubprimer/octicons-react#g' src/**/*.js
```

That should be it! 🤞 