### PR TITLE
[README] Fix typo function name in README

### DIFF
--- a/lib/octicons_react/README.md
+++ b/lib/octicons_react/README.md
@@ -67,7 +67,7 @@ import React from 'react'
 import Octicon, {getIconByName} from '@githubprimer/octicons-react'
 
 export default function OcticonByName({name, ...props}) {
-  return <Octicon {...props} icon={getIcon(name)} />
+  return <Octicon {...props} icon={getIconByName(name)} />
 }
 ```
 


### PR DESCRIPTION
This change replaces `getIcon` with `getIconByName` in README.
`getIconByName` function is imported in the example, but `getIcon` is used (`getIcon` is not imported).
So I guess `getIcon` is a typo of `getIconByName`.