### PR TITLE
Add TypeScript types to the React integration

### DIFF
--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -7,13 +7,14 @@
   "license": "MIT",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
   "repository": "primer/octicons",
   "scripts": {
     "pretest": "npm run lint",
     "test": "jest",
     "start": "NODE_ENV=production next",
     "lint": "eslint src pages script",
-    "prepare": "script/build.js && npm run rollup",
+    "prepare": "script/build.js && script/types.js && npm run rollup",
     "prepublishOnly": "../../script/notify pending",
     "preversion": "npm run prepare",
     "publish": "../../script/notify success",
@@ -28,6 +29,7 @@
     "primer"
   ],
   "dependencies": {
+    "@types/react": "^16.4.6",
     "prop-types": "^15.6.1"
   },
   "devDependencies": {

--- a/lib/octicons_react/script/build.js
+++ b/lib/octicons_react/script/build.js
@@ -5,17 +5,21 @@ const {join, resolve} = require('path')
 
 const srcDir = resolve(__dirname, '../src/__generated__')
 const iconsFile = join(srcDir, 'icons.js')
+const typesFile = join(srcDir, 'icons.d.ts')
 
 function CamelCase(str) {
   return str.replace(/(^|-)([a-z])/g, (_, __, c) => c.toUpperCase())
 }
 
-const icons = [...Object.entries(octicons)]
+const octiconNames = [...Object.entries(octicons)]
+
+const icons = octiconNames
   .map(([key, octicon]) => {
     const name = CamelCase(key)
     const {width, height, path} = octicon
     // convert attributes like fill-rule into JSX equivalents, e.g. fillRule
     const svg = path.replace(/([a-z]+)-([a-z]+)=/g, (_, a, b) => `${a}${CamelCase(b)}=`)
+    const type = `Icon<${width}, ${height}>`
     const code = `function ${name}() {
   return ${svg}
 }
@@ -26,6 +30,7 @@ ${name}.size = [${width}, ${height}]
       key,
       name,
       octicon,
+      type,
       code
     }
   })
@@ -57,9 +62,44 @@ export {
   })
 }
 
+function writeTypes(file) {
+  const count = icons.length
+  const code = `/* THIS FILE IS GENERATED. DO NOT EDIT IT. */
+import * as React from 'react'
+
+type Icon<
+  W extends number = number,
+  H extends number = number
+> = React.SFC<{}> & { size: [W, H] };
+
+${icons.map(({name, type}) => `declare const ${name}: ${type}`).join('\n')}
+
+type IconsByName = {
+  ${icons.map(({key, type}) => `'${key}': ${type}`).join(',\n  ')}
+}
+declare const iconsByName: IconsByName
+
+declare function getIconByName<T extends keyof IconsByName>(
+  name: T
+): IconsByName[T];
+declare function getIconByName(name: string): Icon | undefined
+
+export {
+  Icon,
+  getIconByName,
+  iconsByName,
+  ${icons.map(({name}) => name).join(',\n  ')}
+}`
+  return fse.writeFile(file, code, 'utf8').then(() => {
+    console.warn('wrote %s with %d exports', file, count)
+    return icons
+  })
+}
+
 fse
   .mkdirs(srcDir)
   .then(() => writeIcons(iconsFile))
+  .then(() => writeTypes(typesFile))
   .catch(error => {
     console.error(error)
     process.exit(1)

--- a/lib/octicons_react/script/types.js
+++ b/lib/octicons_react/script/types.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const fse = require('fs-extra')
+const {join, resolve} = require('path')
+
+const srcDir = resolve(__dirname, '../src/__generated__')
+const iconsSrc = join(srcDir, 'icons.d.ts')
+const indexSrc = join(srcDir, '../index.d.ts')
+
+const destDir = resolve(__dirname, '../dist')
+const iconsDest = join(destDir, 'icons.d.ts')
+const indexDest = join(destDir, 'index.d.ts')
+
+fse.copy(iconsSrc, iconsDest).catch(die)
+fse
+  .readFile(indexSrc, 'utf8')
+  .then(content => content.replace(/.\/__generated__\//g, './'))
+  .then(fse.writeFile.bind(fse, indexDest))
+  .catch(die)
+
+function die(err) {
+  console.error(err.stack)
+  process.exit(1)
+}

--- a/lib/octicons_react/src/index.d.ts
+++ b/lib/octicons_react/src/index.d.ts
@@ -1,0 +1,17 @@
+import * as React from 'react'
+
+import {Icon} from './__generated__/icons'
+
+type Size = 'small' | 'medium' | 'large'
+interface OcticonProps {
+  ariaLabel?: string
+  children?: React.ReactElement<any>
+  height?: number
+  icon: Icon
+  size?: number | Size
+  verticalAlign?: 'middle' | 'text-bottom' | 'text-top' | 'top'
+  width?: number
+}
+declare const Octicon: React.SFC<OcticonProps>
+export default Octicon
+export * from './__generated__/icons'


### PR DESCRIPTION
This adds TypeScript types to `@githubprimer/octicons-react`, which allows TypeScript projects to install the module and immediately start using it without installing a separate package. IMO this package should have the types integrated because they need to be generated while building the package to get the most current list of names to export.

The TypeScript types include the exact values for each icon’s `size` property, and calling `getIconByName` with a literal string representing an icon will return the correct type of that icon.

Ref https://github.com/desktop/desktop/issues/5185.