### PR TITLE
Point to new namespace for react lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The octicons node.js library is the main JavaScript library. With [a JavaScript 
 | Package | Version |
 |---|---|
 | **[octicons](/lib/octicons_node)** <br />Node.js package with Javascript API | [![npm version](https://img.shields.io/npm/v/octicons.svg)](https://www.npmjs.org/package/octicons) |
-| **[@github/octicons-react](/lib/octicons_react)** <br />React octicons components | [![npm version](https://img.shields.io/npm/v/%40github%2Focticons-react.svg)](https://www.npmjs.org/package/%40github%2Focticons-react) |
+| **[@github/octicons-react](/lib/octicons_react)** <br />React octicons components | [![npm version](https://img.shields.io/npm/v/%40githubprimer%2Focticons-react.svg)](https://www.npmjs.org/package/%40githubprimer%2Focticons-react) |
 
 ### Ruby
 


### PR DESCRIPTION
`@github/octicons-react` was renamed to `@githubprimer/octicons-react`