### PR TITLE
Fix mortar-board icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bump": "lerna publish --exact --skip-npm --since \"v$(npm info octicons version)\""
   },
   "figma": {
-    "url": "https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons"
+    "url": "https://www.figma.com/file/gP52DTBQNrUyMKOM8X3sSr/Octicons-(Cole's-changes)"
   },
   "devDependencies": {
     "ava": "^0.22.0",


### PR DESCRIPTION
I fixed the issue with the `mortar-board` icon that we noticed earlier today :)

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4608155/47066973-a2216100-d19c-11e8-8c81-4bdf780d94e2.png) |  ![image](https://user-images.githubusercontent.com/4608155/47066998-b4030400-d19c-11e8-8815-6dd31a49721c.png) |

