### PR TITLE
Cleaned up "2" in the list ordered icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bump": "lerna publish --exact --skip-npm --since \"v$(npm info octicons version)\""
   },
   "figma": {
-    "url": "https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons"
+    "url": "https://www.figma.com/file/Hu48dUL5JnMPJpMRNxOdt2/Octicons-Emily-s-Copy?node-id=0%3A1"
   },
   "devDependencies": {
     "ava": "^0.22.0",


### PR DESCRIPTION
![screenshot 2018-11-02 10 51 41](https://user-images.githubusercontent.com/586552/47937916-bc578080-deb8-11e8-9437-d5110d2b2065.png)

The "2" in the `list-ordered` icon has unnecessary path points. This PR is to remove them and clean up the icon!