### PR TITLE
v8.1.1

### DIFF
--- a/lib/octicons_gem/lib/octicons/version.rb
+++ b/lib/octicons_gem/lib/octicons/version.rb
@@ -1,3 +1,3 @@
 module Octicons
-  VERSION = "8.1.0".freeze
+  VERSION = "8.1.1".freeze
 end

--- a/lib/octicons_gem/package.json
+++ b/lib/octicons_gem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octicons_gem",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "Don't install",
   "scripts": {
     "postinstall": "bundle install --path vendor/bundle",

--- a/lib/octicons_helper/lib/octicons_helper/version.rb
+++ b/lib/octicons_helper/lib/octicons_helper/version.rb
@@ -1,3 +1,3 @@
 module OcticonsHelper
-  VERSION = "8.1.0".freeze
+  VERSION = "8.1.1".freeze
 end

--- a/lib/octicons_helper/octicons_helper.gemspec
+++ b/lib/octicons_helper/octicons_helper.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "octicons", "8.1.0"
+  s.add_dependency "octicons", "8.1.1"
   s.add_dependency "rails"
 end

--- a/lib/octicons_helper/package.json
+++ b/lib/octicons_helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octicons_helper",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "A rails helper that makes including svg Octicons simple.",
   "scripts": {
     "version": "../../script/rubyversion ./lib/octicons_helper/version.rb",
@@ -22,6 +22,6 @@
   "rubygems": "octicons_helper",
   "homepage": "https://github.com/primer/octicons#readme",
   "dependencies": {
-    "octicons_gem": "8.1.0"
+    "octicons_gem": "8.1.1"
   }
 }

--- a/lib/octicons_jekyll/jekyll-octicons.gemspec
+++ b/lib/octicons_jekyll/jekyll-octicons.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "jekyll", "~> 3.1"
-  s.add_dependency "octicons", "8.1.0"
+  s.add_dependency "octicons", "8.1.1"
 end

--- a/lib/octicons_jekyll/lib/jekyll-octicons/version.rb
+++ b/lib/octicons_jekyll/lib/jekyll-octicons/version.rb
@@ -3,6 +3,6 @@ module Liquid; class Tag; end; end
 
 module Jekyll
   class Octicons < Liquid::Tag
-    VERSION = "8.1.0".freeze
+    VERSION = "8.1.1".freeze
   end
 end

--- a/lib/octicons_jekyll/package.json
+++ b/lib/octicons_jekyll/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jekyll-octicons",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "A jekyll liquid plugin that makes including svg Octicons simple.",
   "scripts": {
     "version": "../../script/rubyversion ./lib/jekyll-octicons/version.rb",
@@ -21,6 +21,6 @@
   "rubygems": "jekyll-octicons",
   "homepage": "https://github.com/primer/octicons#readme",
   "dependencies": {
-    "octicons_gem": "8.1.0"
+    "octicons_gem": "8.1.1"
   }
 }

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githubprimer/octicons-react",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",
   "author": "GitHub, Inc.",


### PR DESCRIPTION
Here's all the stuff we missed for #253 and what it looks like

```
~/Code/@primer/octicons try_again*
❯ npm run bump

> @ bump /Users/jonrohan/Code/@primer/octicons
> lerna publish --exact --skip-npm --since "v$(npm info octicons version)"

lerna info version 2.11.0
lerna info Checking for updated packages...
lerna info Comparing with v8.1.0.
lerna info Checking for prereleased packages...
lerna info current version 8.1.1
lerna info Checking for updated packages...
lerna info Comparing with v8.1.0.
lerna info Checking for prereleased packages...
? Select a new version (currently 8.1.1) Custom
? Enter a custom version 8.1.1

Changes:
 - octicons_gem: 8.1.1 => 8.1.1
 - octicons_helper: 8.1.1 => 8.1.1
 - jekyll-octicons: 8.1.1 => 8.1.1
 - @githubprimer/octicons-react: 8.1.1 => 8.1.1

? Are you sure you want to publish the above changes? Yes

```