### PR TITLE
Release v8.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.1.2
+
+- Patch release for failed 8.1.1 release
+
 # 8.1.1
 
 - Fix for `list-ordered` icon https://github.com/primer/octicons/pull/252

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
     "lib/octicons_jekyll",
     "lib/octicons_react"
   ],
-  "version": "8.1.1"
+  "version": "8.1.2"
 }

--- a/lib/octicons_gem/lib/octicons/version.rb
+++ b/lib/octicons_gem/lib/octicons/version.rb
@@ -1,3 +1,3 @@
 module Octicons
-  VERSION = "8.1.1".freeze
+  VERSION = "8.1.2".freeze
 end

--- a/lib/octicons_gem/package.json
+++ b/lib/octicons_gem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octicons_gem",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "Don't install",
   "scripts": {
     "postinstall": "bundle install --path vendor/bundle",

--- a/lib/octicons_helper/lib/octicons_helper/version.rb
+++ b/lib/octicons_helper/lib/octicons_helper/version.rb
@@ -1,3 +1,3 @@
 module OcticonsHelper
-  VERSION = "8.1.1".freeze
+  VERSION = "8.1.2".freeze
 end

--- a/lib/octicons_helper/octicons_helper.gemspec
+++ b/lib/octicons_helper/octicons_helper.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "octicons", "8.1.1"
+  s.add_dependency "octicons", "8.1.2"
   s.add_dependency "rails"
 end

--- a/lib/octicons_helper/package.json
+++ b/lib/octicons_helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octicons_helper",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "A rails helper that makes including svg Octicons simple.",
   "scripts": {
     "version": "../../script/rubyversion ./lib/octicons_helper/version.rb",
@@ -22,6 +22,6 @@
   "rubygems": "octicons_helper",
   "homepage": "https://github.com/primer/octicons#readme",
   "dependencies": {
-    "octicons_gem": "8.1.1"
+    "octicons_gem": "8.1.2"
   }
 }

--- a/lib/octicons_jekyll/jekyll-octicons.gemspec
+++ b/lib/octicons_jekyll/jekyll-octicons.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "jekyll", "~> 3.1"
-  s.add_dependency "octicons", "8.1.1"
+  s.add_dependency "octicons", "8.1.2"
 end

--- a/lib/octicons_jekyll/lib/jekyll-octicons/version.rb
+++ b/lib/octicons_jekyll/lib/jekyll-octicons/version.rb
@@ -3,6 +3,6 @@ module Liquid; class Tag; end; end
 
 module Jekyll
   class Octicons < Liquid::Tag
-    VERSION = "8.1.1".freeze
+    VERSION = "8.1.2".freeze
   end
 end

--- a/lib/octicons_jekyll/package.json
+++ b/lib/octicons_jekyll/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jekyll-octicons",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "A jekyll liquid plugin that makes including svg Octicons simple.",
   "scripts": {
     "version": "../../script/rubyversion ./lib/jekyll-octicons/version.rb",
@@ -21,6 +21,6 @@
   "rubygems": "jekyll-octicons",
   "homepage": "https://github.com/primer/octicons#readme",
   "dependencies": {
-    "octicons_gem": "8.1.1"
+    "octicons_gem": "8.1.2"
   }
 }

--- a/lib/octicons_node/package.json
+++ b/lib/octicons_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octicons",
-  "version": "8.1.0",
+  "version": "8.1.2",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",
   "author": "GitHub Inc.",

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githubprimer/octicons-react",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",
   "author": "GitHub, Inc.",
@@ -45,7 +45,7 @@
     "fs-extra": "^6.0.1",
     "jest": "^23.2.0",
     "next": "^5.1.0",
-    "octicons": "7.2.0",
+    "octicons": "8.1.2",
     "primer-react": "0.0.6-alpha.1",
     "react": "^16.4.0",
     "react-dom": "^16.4.1",


### PR DESCRIPTION
This release is a quick patch because of the mistakes made in v8.1.1 release.

Some of the other packages got released for 8.1.1 but not `octicons_node`.