### PR TITLE
Forcing a version change on npm run bump even if none of the source files changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "bootstrap": "lerna bootstrap",
     "test": "ava tests/*.js && lerna run test",
     "lint": "eslint --fix script",
-    "bump": "lerna publish --exact --skip-npm --since \"v$(npm info octicons version)\""
+    "bump": "lerna publish --exact --skip-npm --force-publish --since \"v$(npm info octicons version)\""
   },
   "figma": {
     "url": "https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons"


### PR DESCRIPTION
Using `--force-publish` https://github.com/lerna/lerna/tree/master/commands/version#--force-publish to force a version update when running `npm run bump`.

We're having problems with updating because when only an icon was added, the source code doesn't change. This confuses lerna.

