### PR TITLE
[octicons-react] Add className to the type definition

### DIFF
--- a/lib/octicons_react/src/index.d.ts
+++ b/lib/octicons_react/src/index.d.ts
@@ -6,6 +6,7 @@ type Size = 'small' | 'medium' | 'large'
 export interface OcticonProps {
   ariaLabel?: string
   children?: React.ReactElement<any>
+  className?: string
   height?: number
   icon: Icon
   size?: number | Size

--- a/lib/octicons_react/ts-tests/index.tsx
+++ b/lib/octicons_react/ts-tests/index.tsx
@@ -49,6 +49,12 @@ function VerticalAlign() {
   )
 }
 
+function WithClassName() {
+  return (
+    <Octicon icon={Repo} className="awesomeClassName" />
+  )
+}
+
 const CirclesIcon = createIcon(
   () => {
     return (


### PR DESCRIPTION
Problem
===


octicons-react's `Octicon` component receives `className` as a prop, but the type definition does not include `className` prop.
https://github.com/primer/octicons/blob/7b5d10a4f3af617084b6bd6bc33700b8e04c2470/lib/octicons_react/src/index.js#L17-L18


Solution
===


Add className to the type definition.