### PR TITLE
Creating a version action that versions the release based on PR logic

### DIFF
--- a/.github/actions/version/Dockerfile
+++ b/.github/actions/version/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:10
+
+WORKDIR /
+COPY . /
+RUN npm install
+
+ENTRYPOINT [ "node", "/entrypoint.js" ]

--- a/.github/actions/version/entrypoint.js
+++ b/.github/actions/version/entrypoint.js
@@ -1,0 +1,32 @@
+const semver = require('semver')
+const fs = require('fs')
+const {
+  join,
+  resolve
+} = require('path')
+
+ const {
+  GITHUB_REF,
+  GITHUB_SHA
+} = process.env
+const pkg = require(resolve(process.cwd(), 'package.json'))
+const branchName = GITHUB_REF.split('/').pop()
+
+ const writePackageJson = () => {
+  fs.writeFileSync(join(process.cwd(), 'package.json'), JSON.stringify(pkg), 'utf8')
+}
+
+ // If it's a release branch
+if (branchName.match(/^release-/i)) {
+  console.log('Versioning release candidate')
+  const newVersion = branchName.match(/^release-([\d\.]+)/i)
+  pkg.version = `${newVersion[1]}-rc.${GITHUB_SHA.slice(0,7)}`
+  writePackageJson()
+}
+
+ // Otherwise
+else if (branchName != 'master') {
+  console.log('Versioning prerelease')
+  pkg.version = `${semver.inc(pkg.version, 'patch')}-alpha.${GITHUB_SHA.slice(0,7)}`
+  writePackageJson()
+}

--- a/.github/actions/version/entrypoint.js
+++ b/.github/actions/version/entrypoint.js
@@ -16,7 +16,7 @@ const writePackageJson = () => {
   fs.writeFileSync(join(process.cwd(), 'package.json'), JSON.stringify(pkg), 'utf8')
 }
 
- // If it's a release branch
+// If it's a release branch
 if (branchName.match(/^release-/i)) {
   console.log('Versioning release candidate')
   const newVersion = branchName.match(/^release-([\d\.]+)/i)

--- a/.github/actions/version/entrypoint.js
+++ b/.github/actions/version/entrypoint.js
@@ -13,7 +13,7 @@ const {
 const pkg = require(resolve(process.cwd(), 'package.json'))
 
 // GitHub info
-const branchName = GITHUB_REF.replace(/^refs\/(heads|remotes\/origins)\//gi, "")
+const branchName = GITHUB_REF.replace(/^refs\/heads\//gi, "")
 const shortSha = GITHUB_SHA.slice(0,7)
 let releaseMatch = null
 

--- a/.github/actions/version/entrypoint.js
+++ b/.github/actions/version/entrypoint.js
@@ -4,15 +4,15 @@ const {
   join,
   resolve
 } = require('path')
-
  const {
   GITHUB_REF,
   GITHUB_SHA
 } = process.env
-const pkg = require(resolve(process.cwd(), 'package.json'))
-const branchName = GITHUB_REF.split('/').pop()
 
- const writePackageJson = () => {
+const pkg = require(resolve(process.cwd(), 'package.json'))
+const branchName = GITHUB_REF.replace(/^refs\/(heads|remotes\/origins)\//gi, "")
+
+const writePackageJson = () => {
   fs.writeFileSync(join(process.cwd(), 'package.json'), JSON.stringify(pkg), 'utf8')
 }
 

--- a/.github/actions/version/entrypoint.js
+++ b/.github/actions/version/entrypoint.js
@@ -9,24 +9,31 @@ const {
   GITHUB_SHA
 } = process.env
 
+// Octicons package
 const pkg = require(resolve(process.cwd(), 'package.json'))
+
+// GitHub info
 const branchName = GITHUB_REF.replace(/^refs\/(heads|remotes\/origins)\//gi, "")
+const shortSha = GITHUB_SHA.slice(0,7)
+let releaseMatch = null
 
 const writePackageJson = () => {
   fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2), 'utf8')
 }
 
 // If it's a release branch
-if (branchName.match(/^release-/i)) {
+if (releaseMatch = branchName.match(/^release-([\d\.]+)/i)) {
   console.log('Versioning release candidate')
-  const newVersion = branchName.match(/^release-([\d\.]+)/i)
-  pkg.version = `${newVersion[1]}-rc.${GITHUB_SHA.slice(0,7)}`
+  console.log(`${pkg.version} => ${releaseMatch[1]}`)
+  pkg.version = `${releaseMatch[1]}-rc.${shortSha}`
   writePackageJson()
 }
 
  // Otherwise
 else if (branchName != 'master') {
+  const newVersion = `${semver.inc(pkg.version, 'patch')}-alpha.${shortSha}`
   console.log('Versioning prerelease')
-  pkg.version = `${semver.inc(pkg.version, 'patch')}-alpha.${GITHUB_SHA.slice(0,7)}`
+  console.log(`${pkg.version} => ${newVersion}`)
+  pkg.version = newVersion
   writePackageJson()
 }

--- a/.github/actions/version/entrypoint.js
+++ b/.github/actions/version/entrypoint.js
@@ -13,7 +13,7 @@ const pkg = require(resolve(process.cwd(), 'package.json'))
 const branchName = GITHUB_REF.replace(/^refs\/(heads|remotes\/origins)\//gi, "")
 
 const writePackageJson = () => {
-  fs.writeFileSync(join(process.cwd(), 'package.json'), JSON.stringify(pkg), 'utf8')
+  fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2), 'utf8')
 }
 
 // If it's a release branch

--- a/.github/actions/version/package.json
+++ b/.github/actions/version/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "scripts": {
+    "start": "node entrypoint.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "semver": "5.6.0"
+  }
+}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,7 +1,8 @@
 workflow "Octicons" {
   on = "push"
   resolves = [
-    "lint"
+    "lint",
+    "version"
   ]
 }
 
@@ -14,4 +15,9 @@ action "lint" {
   needs = ["install"]
   uses = "actions/npm@master"
   args = "run lint"
+}
+
+action "version" {
+  needs = ["install"]
+  uses = "./.github/actions/version"
 }


### PR DESCRIPTION
This action updates the root `package.json` with a version number based on our primer workflow logic. After updating the version in `package.json` the actions down in the workflow will be able to read this number and publish/update packages.

#### Logic

1. If the pull request branch begins with `release-` then treat that as a release candidate. Grab the version number from the branch name eg `release-8.0.0 => 8.0.0`. The version number will end up with a `rc` postfix and the commit short sha. eg. `8.0.0-rc.1cd4n78`
2. If the pull request isn't `master` and isn't a `release-` branch, then treat this as an alpha release. Using the current version number from package, it will bump it to a patch release and add a postfix of alpha and the commit sha. eg `8.0.0 => 8.0.1-alpha.1cd4n78`

@shawnbot @emplums 