### PR TITLE
Patch release v8.4.1

### DIFF
--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -13,10 +13,11 @@
     "build": "script/build.js && script/types.js",
     "ts-test": "tsc -P ts-tests",
     "test": "jest",
+    "prepare": "npm run build && npm run rollup",
+    "preversion": "npm run prepare",
     "posttest": "npm run ts-test",
     "start": "NODE_ENV=production next",
     "lint": "eslint src pages script",
-    "prepare": "npm run build && npm run rollup",
     "rollup": "rollup -c"
   },
   "keywords": [

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -10,11 +10,9 @@
   "types": "dist/index.d.ts",
   "repository": "primer/octicons",
   "scripts": {
-    "build": "script/build.js && script/types.js",
+    "build": "script/build.js && script/types.js && npm run rollup",
     "ts-test": "tsc -P ts-tests",
     "test": "jest",
-    "prepare": "npm run build && npm run rollup",
-    "preversion": "npm run prepare",
     "posttest": "npm run ts-test",
     "start": "NODE_ENV=production next",
     "lint": "eslint src pages script",


### PR DESCRIPTION
Version 8.4.0 broke Octicons React. The proper rollup files weren't being generated during the build and not added to the distribution.

fixes https://github.com/primer/octicons/issues/282

Thanks for the report @deedubbu 🐛 