### PR TITLE
Patch release v8.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 8.4.1
+
+### :bug: Bug Fix
+- Rollup files missing from octicons react package https://github.com/primer/octicons/issues/282
+
 # 8.4.0
 
 ### :house: Internal

--- a/lib/octicons_gem/lib/octicons/version.rb
+++ b/lib/octicons_gem/lib/octicons/version.rb
@@ -1,3 +1,3 @@
 module Octicons
-  VERSION = "8.4.0".freeze
+  VERSION = "8.4.1".freeze
 end

--- a/lib/octicons_helper/Gemfile
+++ b/lib/octicons_helper/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "octicons", "8.4.0"
+gem "octicons", "8.4.1"
 gem "rails"
 
 group :development, :test do

--- a/lib/octicons_helper/lib/octicons_helper/version.rb
+++ b/lib/octicons_helper/lib/octicons_helper/version.rb
@@ -1,3 +1,3 @@
 module OcticonsHelper
-  VERSION = "8.4.0".freeze
+  VERSION = "8.4.1".freeze
 end

--- a/lib/octicons_helper/octicons_helper.gemspec
+++ b/lib/octicons_helper/octicons_helper.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "octicons", "8.4.0"
+  s.add_dependency "octicons", "8.4.1"
   s.add_dependency "rails"
 end

--- a/lib/octicons_jekyll/Gemfile
+++ b/lib/octicons_jekyll/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "octicons", "8.4.0"
+gem "octicons", "8.4.1"
 
 group :development, :test do
   gem "minitest"

--- a/lib/octicons_jekyll/jekyll-octicons.gemspec
+++ b/lib/octicons_jekyll/jekyll-octicons.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "jekyll", "~> 3.1"
-  s.add_dependency "octicons", "8.4.0"
+  s.add_dependency "octicons", "8.4.1"
 end

--- a/lib/octicons_jekyll/lib/jekyll-octicons/version.rb
+++ b/lib/octicons_jekyll/lib/jekyll-octicons/version.rb
@@ -3,6 +3,6 @@ module Liquid; class Tag; end; end
 
 module Jekyll
   class Octicons < Liquid::Tag
-    VERSION = "8.4.0".freeze
+    VERSION = "8.4.1".freeze
   end
 end

--- a/lib/octicons_node/package-lock.json
+++ b/lib/octicons_node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "octicons",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lib/octicons_node/package.json
+++ b/lib/octicons_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octicons",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",
   "author": "GitHub Inc.",

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -13,10 +13,11 @@
     "build": "script/build.js && script/types.js",
     "ts-test": "tsc -P ts-tests",
     "test": "jest",
+    "prepare": "npm run build && npm run rollup",
+    "preversion": "npm run prepare",
     "posttest": "npm run ts-test",
     "start": "NODE_ENV=production next",
     "lint": "eslint src pages script",
-    "prepare": "npm run build && npm run rollup",
     "rollup": "rollup -c"
   },
   "keywords": [

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@githubprimer/octicons-react",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",
   "author": "GitHub, Inc.",

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -10,11 +10,9 @@
   "types": "dist/index.d.ts",
   "repository": "primer/octicons",
   "scripts": {
-    "build": "script/build.js && script/types.js",
+    "build": "script/build.js && script/types.js && npm run rollup",
     "ts-test": "tsc -P ts-tests",
     "test": "jest",
-    "prepare": "npm run build && npm run rollup",
-    "preversion": "npm run prepare",
     "posttest": "npm run ts-test",
     "start": "NODE_ENV=production next",
     "lint": "eslint src pages script",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.4.0",
+  "version": "8.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "8.4.0",
+  "version": "8.4.1",
   "scripts": {
     "version": "script/version",
     "test": "ava tests/*.js",


### PR DESCRIPTION
Version 8.4.0 broke Octicons React. The proper rollup files weren't being generated during the build and not added to the distribution.

fixes https://github.com/primer/octicons/issues/282

Thanks for the report @deedubbu 🐛 

whoops, wrong branch name. closing https://github.com/primer/octicons/pull/283