### PR TITLE
minor fixes to correct svg weirdness and frame sizes

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -38,7 +38,7 @@ action "Export SVG from Figma" {
     "FIGMA_TOKEN"
   ]
   env = {
-    "FIGMA_FILE_URL" = "https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons"
+    "FIGMA_FILE_URL" = "https://www.figma.com/file/Hm9oWky2Sly3k5dzWVau0k/Octicons-Ash-s-updates"
   }
   args = [
     "format=svg",

--- a/lib/octicons_gem/test/octicon_test.rb
+++ b/lib/octicons_gem/test/octicon_test.rb
@@ -27,14 +27,14 @@ describe Octicons::Octicon do
     assert icon.path
     assert icon.options
     assert_equal "x", icon.symbol
-    assert_equal 12, icon.width
+    assert_equal 16, icon.width
     assert_equal 16, icon.height
   end
 
   describe "viewBox" do
     it "always has a viewBox" do
       icon = octicon("x")
-      assert_includes icon.to_svg, "viewBox=\"0 0 12 16\""
+      assert_includes icon.to_svg, "viewBox=\"0 0 16 16\""
     end
   end
 
@@ -57,30 +57,30 @@ describe Octicons::Octicon do
     it "always has width and height" do
       icon = octicon("x")
       assert_includes icon.to_svg, "height=\"16\""
-      assert_includes icon.to_svg, "width=\"12\""
+      assert_includes icon.to_svg, "width=\"16\""
     end
 
     it "converts number string height to integer" do
       icon = octicon("x", height: "60")
       assert_includes icon.to_svg, "height=\"60\""
-      assert_includes icon.to_svg, "width=\"45\""
+      assert_includes icon.to_svg, "width=\"60\""
     end
 
     it "converts number height to integer" do
       icon = octicon("x", height: 60)
       assert_includes icon.to_svg, "height=\"60\""
-      assert_includes icon.to_svg, "width=\"45\""
+      assert_includes icon.to_svg, "width=\"60\""
     end
 
     it "converts number string width to integer" do
       icon = octicon("x", width: "45")
-      assert_includes icon.to_svg, "height=\"60\""
+      assert_includes icon.to_svg, "height=\"45\""
       assert_includes icon.to_svg, "width=\"45\""
     end
 
     it "converts number width to integer" do
       icon = octicon("x", width: 45)
-      assert_includes icon.to_svg, "height=\"60\""
+      assert_includes icon.to_svg, "height=\"45\""
       assert_includes icon.to_svg, "width=\"45\""
     end
 

--- a/lib/octicons_node/tests/index.js
+++ b/lib/octicons_node/tests/index.js
@@ -100,5 +100,5 @@ test('Passing in width will size properly', t => {
 
 test('Passing in height will size properly', t => {
   const svg = octicons['x'].toSVG({width: 45})
-  t.regex(svg, new RegExp('height="60"'), 'The octicon "x" doesn\'t have the height attribute scaled properly')
+  t.regex(svg, new RegExp('height="45"'), 'The octicon "x" doesn\'t have the height attribute scaled properly')
 })

--- a/lib/octicons_node/tests/index.js
+++ b/lib/octicons_node/tests/index.js
@@ -95,7 +95,7 @@ test('Passing in aria-label will update the a11y options', t => {
 
 test('Passing in width will size properly', t => {
   const svg = octicons['x'].toSVG({height: 60})
-  t.regex(svg, new RegExp('width="45"'), 'The octicon "x" doesn\'t have the width attribute scaled properly')
+  t.regex(svg, new RegExp('width="60"'), 'The octicon "x" doesn\'t have the width attribute scaled properly')
 })
 
 test('Passing in height will size properly', t => {


### PR DESCRIPTION
* fixed `thumbs-up` and `thumbs-down` icons to correct svg sizing
* updated frame sizes to be consistent at a `16x16` grid except for the Logos octicons
* proposed refresh for `arrow-both` to fit in `16x16` grid