### PR TITLE
Fix octicons_gem including aria-hidden when aria-label is present

### DIFF
--- a/lib/octicons_gem/lib/octicons/octicon.rb
+++ b/lib/octicons_gem/lib/octicons/octicon.rb
@@ -43,8 +43,8 @@ module Octicons
     def a11y
       accessible = {}
 
-      if @options[:'aria-label'].nil?
-        accessible[:'aria-hidden'] = "true"
+      if @options[:"aria-label"].nil? && @options["aria-label"].nil?
+        accessible[:"aria-hidden"] = "true"
       else
         accessible[:role] = "img"
       end

--- a/lib/octicons_gem/test/octicon_test.rb
+++ b/lib/octicons_gem/test/octicon_test.rb
@@ -92,10 +92,18 @@ describe Octicons::Octicon do
   end
 
   describe "a11y" do
-    it "includes attributes" do
+    it "includes attributes for symbol keys" do
       icon = octicon("x", "aria-label": "Close")
       assert_includes icon.to_svg, "role=\"img\""
       assert_includes icon.to_svg, "aria-label=\"Close\""
+      refute_includes icon.to_svg, "aria-hidden"
+    end
+
+    it "includes attributes for string keys" do
+      icon = octicon("x", "aria-label" => "Close")
+      assert_includes icon.to_svg, "role=\"img\""
+      assert_includes icon.to_svg, "aria-label=\"Close\""
+      refute_includes icon.to_svg, "aria-hidden"
     end
 
     it "has aria-hidden when no label is passed in" do


### PR DESCRIPTION
Octicons gem should check for keys of both symbol and string types.

---

I was unable to run the test locally because it is looking for a mysterious `./build/data.json` file, and I can't find instructions for building one locally. 🤔 