### PR TITLE
Scoping npm packages to organization @primer/octicons  and @primer/octicons-react

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Latest
+
+- Scoping packages to organization `@primer/octicons` and `@primer/octicons-react` @jonrohan
+
 # 8.5.0
 
 - a11y aria-hidden update from @muan https://github.com/primer/octicons/pull/295

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The octicons node.js library is the main JavaScript library. With [a JavaScript 
 
 | Package | Version |
 |---|---|
-| **[octicons](/lib/octicons_node)** <br />Node.js package with Javascript API | [![npm version](https://img.shields.io/npm/v/octicons.svg)](https://www.npmjs.org/package/octicons) |
-| **[@githubprimer/octicons-react](/lib/octicons_react)** <br />React octicons components | [![npm version](https://img.shields.io/npm/v/@githubprimer/octicons-react.svg)](https://www.npmjs.org/package/@githubprimer/octicons-react) |
+| **[@primer/octicons](/lib/octicons_node)** <br />Node.js package with Javascript API | [![npm version](https://img.shields.io/npm/v/@primer/octicons.svg)](https://www.npmjs.org/package/@primer/octicons) |
+| **[@primer/octicons-react](/lib/octicons_react)** <br />React octicons components | [![npm version](https://img.shields.io/npm/v/@primer/octicons-react.svg)](https://www.npmjs.org/package/@primer/octicons-react) |
 
 ### Ruby
 
@@ -37,7 +37,7 @@ The octicons node.js library is the main JavaScript library. With [a JavaScript 
 
 When using the GitHub logos, be sure to follow the [GitHub logo guidelines](https://github.com/logos).
 
-_Code License:_ [MIT](./LICENSE)  
+_Code License:_ [MIT](./LICENSE)
 Applies to all other files
 
 [figma-file]: https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons

--- a/lib/octicons_node/README.md
+++ b/lib/octicons_node/README.md
@@ -1,7 +1,6 @@
 # GitHub Octicons
 
-[![npm version](https://img.shields.io/npm/v/octicons.svg)](https://www.npmjs.org/package/octicons)
-[![Build Status](https://travis-ci.org/primer/octicons.svg?branch=master)](https://travis-ci.org/primer/octicons)
+[![npm version](https://img.shields.io/npm/v/@primer/octicons.svg)](https://www.npmjs.org/package/@primer/octicons)
 
 > Octicons are a scalable set of icons handcrafted with <3 by GitHub.
 
@@ -133,7 +132,7 @@ octicons.x.toSVG({ "width": 45 })
 
 When using the GitHub logos, be sure to follow the [GitHub logo guidelines](https://github.com/logos).
 
-[MIT](./LICENSE)  
+[MIT](./LICENSE)
 
 [primer]: https://github.com/primer/primer
 [docs]: http://primercss.io/

--- a/lib/octicons_node/package.json
+++ b/lib/octicons_node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "octicons",
+  "name": "@primer/octicons",
   "version": "8.5.0",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",

--- a/lib/octicons_react/README.md
+++ b/lib/octicons_react/README.md
@@ -1,7 +1,6 @@
 # [Octicons] for React
 
-[![npm version](https://img.shields.io/npm/v/@githubprimer/octicons-react.svg)](https://www.npmjs.org/package/@githubprimer/octicons-react)
-[![Build Status](https://travis-ci.org/primer/octicons.svg?branch=master)](https://travis-ci.org/primer/octicons)
+[![npm version](https://img.shields.io/npm/v/@primer/octicons-react.svg)](https://www.npmjs.org/package/@primer/octicons-react)
 
 ## Install
 
@@ -187,7 +186,7 @@ export default CirclesOcticon(props) {
 When using the GitHub logos, be sure to follow the [GitHub logo
 guidelines](https://github.com/logos).
 
-[MIT](./LICENSE)  
+[MIT](./LICENSE)
 
 [octicons]: https://octicons.github.com/
 [primer]: https://github.com/primer/primer

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@githubprimer/octicons-react",
+  "name": "@primer/octicons-react",
   "version": "8.5.0",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",


### PR DESCRIPTION
This updates both the npm octicons package and the npm octicons-react package to live under the `@primer` org name.

@shawnbot 