### PR TITLE
Update gemspec to allow for Jekyll 4.0

### DIFF
--- a/lib/octicons_jekyll/jekyll-octicons.gemspec
+++ b/lib/octicons_jekyll/jekyll-octicons.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "jekyll", "~> 3.1"
+  s.add_dependency "jekyll", ">= 3.6", "< 5.0"
   s.add_dependency "octicons", "9.1.1"
 end


### PR DESCRIPTION
Jekyll 4.0 seems to work fine with this plugin, but the spec doesnt allow it.