### PR TITLE
[React] Allow 'unset' value for verticalAlign property

### DIFF
--- a/lib/octicons_react/src/index.d.ts
+++ b/lib/octicons_react/src/index.d.ts
@@ -10,7 +10,7 @@ export interface OcticonProps {
   height?: number
   icon: Icon
   size?: number | Size
-  verticalAlign?: 'middle' | 'text-bottom' | 'text-top' | 'top'
+  verticalAlign?: 'middle' | 'text-bottom' | 'text-top' | 'top' | 'unset'
   width?: number
 }
 

--- a/lib/octicons_react/src/index.js
+++ b/lib/octicons_react/src/index.js
@@ -62,7 +62,7 @@ Octicon.propTypes = {
   height: PropTypes.number,
   icon: PropTypes.func,
   size: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(Object.keys(sizeMap))]),
-  verticalAlign: PropTypes.oneOf(['middle', 'text-bottom', 'text-top', 'top']),
+  verticalAlign: PropTypes.oneOf(['middle', 'text-bottom', 'text-top', 'top', 'unset']),
   width: PropTypes.number
 }
 


### PR DESCRIPTION
This PR adjusts type-checking of the React Octicon component to allow users to set the `verticalAlign` property to `unset`.
I'm currently using Octicons for a project of mine and without this change I can't perfectly center an octicon vertically inside a flex container, since `vertical-align` CSS property on the icon clashes with flex `align-items`.