### PR TITLE
Release 9.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+# 9.3.1
+
+## Bugfix
+
+- Workflow icon had a cutoff edge.
+
 # 9.3.0
 
 ### 🚀 New Features
 
-- Workflow icons https://github.com/primer/octicons/pull/356 @ashygee 
+- Workflow icons https://github.com/primer/octicons/pull/356 @ashygee
 - Allow 'unset' value for verticalAlign property https://github.com/primer/octicons/pull/354 @Fs00
 
 # 9.2.0

--- a/lib/octicons_gem/lib/octicons/version.rb
+++ b/lib/octicons_gem/lib/octicons/version.rb
@@ -1,3 +1,3 @@
 module Octicons
-  VERSION = "9.3.0".freeze
+  VERSION = "9.3.1".freeze
 end

--- a/lib/octicons_helper/Gemfile
+++ b/lib/octicons_helper/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "octicons", "9.3.0"
+gem "octicons", "9.3.1"
 gem "rails"
 
 group :development, :test do

--- a/lib/octicons_helper/lib/octicons_helper/version.rb
+++ b/lib/octicons_helper/lib/octicons_helper/version.rb
@@ -1,3 +1,3 @@
 module OcticonsHelper
-  VERSION = "9.3.0".freeze
+  VERSION = "9.3.1".freeze
 end

--- a/lib/octicons_helper/octicons_helper.gemspec
+++ b/lib/octicons_helper/octicons_helper.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "octicons", "9.3.0"
+  s.add_dependency "octicons", "9.3.1"
   s.add_dependency "rails"
 end

--- a/lib/octicons_jekyll/Gemfile
+++ b/lib/octicons_jekyll/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "octicons", "9.3.0"
+gem "octicons", "9.3.1"
 
 group :development, :test do
   gem "minitest"

--- a/lib/octicons_jekyll/jekyll-octicons.gemspec
+++ b/lib/octicons_jekyll/jekyll-octicons.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "jekyll", ">= 3.6", "< 5.0"
-  s.add_dependency "octicons", "9.3.0"
+  s.add_dependency "octicons", "9.3.1"
 end

--- a/lib/octicons_jekyll/lib/jekyll-octicons/version.rb
+++ b/lib/octicons_jekyll/lib/jekyll-octicons/version.rb
@@ -3,6 +3,6 @@ module Liquid; class Tag; end; end
 
 module Jekyll
   class Octicons < Liquid::Tag
-    VERSION = "9.3.0".freeze
+    VERSION = "9.3.1".freeze
   end
 end

--- a/lib/octicons_node/package-lock.json
+++ b/lib/octicons_node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/octicons",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lib/octicons_node/package.json
+++ b/lib/octicons_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/octicons",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",
   "author": "GitHub Inc.",

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/octicons-react",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",
   "author": "GitHub, Inc.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "version": "9.3.0",
+  "version": "9.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "9.3.0",
+  "version": "9.3.1",
   "scripts": {
     "version": "script/version",
     "test": "ava -v tests/*.js",


### PR DESCRIPTION
Bugfix

- The workflow icon had a cutoff edge because the viewport wasn't 16x16 on export.

![image](https://user-images.githubusercontent.com/54012/69464107-4d063600-0d32-11ea-8dd1-a5442b3c390a.png)

@jasonlong 