### PR TITLE
Adds infinity, line-arrow, and heart-outline symbols, cleans up heart icon path

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Export SVG from Figma
       uses: primer/figma-action@d7844a1927da9b8dd562cbf008c7da20e228607d
       env:
-        FIGMA_FILE_URL: https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons
+        FIGMA_FILE_URL: https://www.figma.com/file/KeVvQazRDZKeTmT9By0bnZ/Octicons-Bryn-s-changes?node-id=0%3A1
         FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
       with:
         args: format=svg dir=./lib/build


### PR DESCRIPTION
title | image | description
-----------|---|---
`heart` glyph updates | ![image](https://user-images.githubusercontent.com/4926824/71935230-23c32d00-315b-11ea-84bf-95013e6246b8.png) | Outlining the heart in the glyph vs via css enables the stroke to be centered on the path without increasing the glyph frame dimensions. Regardless of stroking method, the inset point needs to be slightly rounded or the angle increases in an awkward manner. This also updates the vertical centering in the frame to make it easier to align with text.
`heart` glyph diff detail | ![image](https://user-images.githubusercontent.com/4926824/71934854-30935100-315a-11ea-8e9d-f6ed5e30b257.png) | There were a few unnecessary points on the path with some misaligned beziers that made it slightly bumpy, rather than smooth.
`infinity` glyph ([proposal/rationale](https://github.com/primer/octicons/issues/349)) | ![image](https://user-images.githubusercontent.com/4926824/71934660-c5e21580-3159-11ea-8f9a-1e0842bdf90b.png) | This is for use on pricing pages for features marked as "unlimited" (e.g. contributors, repos, etc.)
`line-arrow` glyphs | ![image](https://user-images.githubusercontent.com/4926824/71934760-f9bd3b00-3159-11ea-9f5b-2c5e90a805cb.png) | These are based on the caret/chevron symbols and are used on pricing pages to denote "<- contains all of these features". We also use the up arrow on small screens when the plans reorient to be vertically-listed.

cc @katmeister