### PR TITLE
Namespace octicons v2 for use alongside v1

### DIFF
--- a/lib/octicons_gem/Rakefile
+++ b/lib/octicons_gem/Rakefile
@@ -12,10 +12,10 @@ Rake::TestTask.new do |t|
 end
 
 task :version, [:v] do |t, args|
-  out = "module Octicons\n"\
+  out = "module OcticonsV2\n"\
     "  VERSION = \"#{args[:v]}\".freeze\n"\
     "end"
-  File.open(File.expand_path("../lib/octicons/version.rb", __FILE__), "w") { |file| file.puts out }
+  File.open(File.expand_path("../lib/octicons_v2/version.rb", __FILE__), "w") { |file| file.puts out }
 end
 
 desc "Run tests"

--- a/lib/octicons_gem/lib/octicons_v2.rb
+++ b/lib/octicons_gem/lib/octicons_v2.rb
@@ -1,8 +1,8 @@
-require "octicons/version"
-require "octicons/octicon"
+require "octicons_v2/version"
+require "octicons_v2/octicon_v2"
 require "json"
 
-module Octicons
+module OcticonsV2
   file_data = File.read(File.join(File.dirname(__FILE__), "./build/data.json"))
   OCTICON_SYMBOLS = JSON.parse(file_data).freeze
 end

--- a/lib/octicons_gem/lib/octicons_v2/octicon_v2.rb
+++ b/lib/octicons_gem/lib/octicons_v2/octicon_v2.rb
@@ -1,11 +1,11 @@
-module Octicons
-  class Octicon
+module OcticonsV2
+  class OcticonV2
 
     attr_reader :path, :options, :width, :height, :symbol, :keywords
 
     def initialize(symbol, options = {})
       @symbol = symbol.to_s
-      if octicon = Octicons::OCTICON_SYMBOLS[@symbol]
+      if octicon = OcticonsV2::OCTICON_SYMBOLS[@symbol]
 
         @path = octicon["path"]
         @width = octicon["width"].to_i

--- a/lib/octicons_gem/lib/octicons_v2/version.rb
+++ b/lib/octicons_gem/lib/octicons_v2/version.rb
@@ -1,3 +1,3 @@
-module OcticonsHelper
+module OcticonsV2
   VERSION = "9.4.0".freeze
 end

--- a/lib/octicons_gem/octicons_v2.gemspec
+++ b/lib/octicons_gem/octicons_v2.gemspec
@@ -1,8 +1,8 @@
-require File.expand_path("../lib/octicons/version", __FILE__)
+require File.expand_path("../lib/octicons_v2/version", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "octicons_v2"
-  s.version     = Octicons::VERSION
+  s.version     = OcticonsV2::VERSION
   s.summary     = "GitHub's octicons gem"
   s.platform    = Gem::Platform::RUBY
   s.description = "A package that distributes Octicons in a gem"

--- a/lib/octicons_gem/test/helper.rb
+++ b/lib/octicons_gem/test/helper.rb
@@ -1,6 +1,6 @@
 require "minitest/autorun"
-require "octicons"
+require "octicons_v2"
 
-def octicon(symbol, options = {})
-  ::Octicons::Octicon.new(symbol, options)
+def octicon_v2(symbol, options = {})
+  ::OcticonsV2::OcticonV2.new(symbol, options)
 end

--- a/lib/octicons_gem/test/octicon_test.rb
+++ b/lib/octicons_gem/test/octicon_test.rb
@@ -1,29 +1,29 @@
 require_relative "./helper"
 
-describe Octicons::Octicon do
+describe OcticonsV2::OcticonV2 do
   it "fails when the octicon doesn't exist" do
     assert_raises(RuntimeError) do
-      octicon("octicon")
+      octicon_v2("octicon")
     end
   end
 
   it "initialize accepts a string for an icon" do
-    icon = octicon("x")
+    icon = octicon_v2("x")
     assert icon
   end
 
   it "initialize accepts a symbol for an icon" do
-    icon = octicon(:x)
+    icon = octicon_v2(:x)
     assert icon
   end
 
   it "gets keywords for the icon" do
-    icon = octicon("mark-github")
+    icon = octicon_v2("mark-github")
     assert_equal ["octocat", "brand", "github", "logo"], icon.keywords
   end
 
   it "the attributes are readable" do
-    icon = octicon("x")
+    icon = octicon_v2("x")
     assert icon.path
     assert icon.options
     assert_equal "x", icon.symbol
@@ -33,14 +33,14 @@ describe Octicons::Octicon do
 
   describe "viewBox" do
     it "always has a viewBox" do
-      icon = octicon("x")
+      icon = octicon_v2("x")
       assert_includes icon.to_svg, "viewBox=\"0 0 16 16\""
     end
   end
 
   describe "html_attributes" do
     it "includes other html attributes" do
-      icon = octicon("x", foo: "bar", disabled: "true")
+      icon = octicon_v2("x", foo: "bar", disabled: "true")
       assert_includes icon.to_svg, "disabled=\"true\""
       assert_includes icon.to_svg, "foo=\"bar\""
     end
@@ -48,44 +48,44 @@ describe Octicons::Octicon do
 
   describe "classes" do
     it "includes classes passed in" do
-      icon = octicon("x", class: "text-closed")
+      icon = octicon_v2("x", class: "text-closed")
       assert_includes icon.to_svg, "class=\"octicon octicon-x text-closed\""
     end
   end
 
   describe "size" do
     it "always has width and height" do
-      icon = octicon("x")
+      icon = octicon_v2("x")
       assert_includes icon.to_svg, "height=\"16\""
       assert_includes icon.to_svg, "width=\"16\""
     end
 
     it "converts number string height to integer" do
-      icon = octicon("x", height: "60")
+      icon = octicon_v2("x", height: "60")
       assert_includes icon.to_svg, "height=\"60\""
       assert_includes icon.to_svg, "width=\"60\""
     end
 
     it "converts number height to integer" do
-      icon = octicon("x", height: 60)
+      icon = octicon_v2("x", height: 60)
       assert_includes icon.to_svg, "height=\"60\""
       assert_includes icon.to_svg, "width=\"60\""
     end
 
     it "converts number string width to integer" do
-      icon = octicon("x", width: "45")
+      icon = octicon_v2("x", width: "45")
       assert_includes icon.to_svg, "height=\"45\""
       assert_includes icon.to_svg, "width=\"45\""
     end
 
     it "converts number width to integer" do
-      icon = octicon("x", width: 45)
+      icon = octicon_v2("x", width: 45)
       assert_includes icon.to_svg, "height=\"45\""
       assert_includes icon.to_svg, "width=\"45\""
     end
 
     it "with height and width passed in" do
-      icon = octicon("x", width: 60, height: 60)
+      icon = octicon_v2("x", width: 60, height: 60)
       assert_includes icon.to_svg, "width=\"60\""
       assert_includes icon.to_svg, "height=\"60\""
     end
@@ -93,21 +93,21 @@ describe Octicons::Octicon do
 
   describe "a11y" do
     it "includes attributes for symbol keys" do
-      icon = octicon("x", "aria-label": "Close")
+      icon = octicon_v2("x", "aria-label": "Close")
       assert_includes icon.to_svg, "role=\"img\""
       assert_includes icon.to_svg, "aria-label=\"Close\""
       refute_includes icon.to_svg, "aria-hidden"
     end
 
     it "includes attributes for string keys" do
-      icon = octicon("x", "aria-label" => "Close")
+      icon = octicon_v2("x", "aria-label" => "Close")
       assert_includes icon.to_svg, "role=\"img\""
       assert_includes icon.to_svg, "aria-label=\"Close\""
       refute_includes icon.to_svg, "aria-hidden"
     end
 
     it "has aria-hidden when no label is passed in" do
-      icon = octicon("x")
+      icon = octicon_v2("x")
       assert_includes icon.to_svg, "aria-hidden=\"true\""
     end
   end

--- a/lib/octicons_gem/test/octicons_test.rb
+++ b/lib/octicons_gem/test/octicons_test.rb
@@ -1,9 +1,9 @@
 require_relative "./helper"
 
-describe Octicons do
+describe OcticonsV2 do
   it "loads all icons on initialization" do
-    refute_equal 0, Octicons::OCTICON_SYMBOLS.length
-    x_icon = Octicons::OCTICON_SYMBOLS["x"]
+    refute_equal 0, OcticonsV2::OCTICON_SYMBOLS.length
+    x_icon = OcticonsV2::OCTICON_SYMBOLS["x"]
     assert x_icon["keywords"]
     assert x_icon["path"]
     assert x_icon["height"]

--- a/lib/octicons_helper/Rakefile
+++ b/lib/octicons_helper/Rakefile
@@ -7,14 +7,14 @@ RuboCop::RakeTask.new(:lint) do |t|
 end
 
 task :version, [:v] do |t, args|
-  out = "module OcticonsHelper\n"\
+  out = "module OcticonsV2Helper\n"\
     "  VERSION = \"#{args[:v]}\".freeze\n"\
     "end"
-  File.open(File.expand_path("../lib/octicons_helper/version.rb", __FILE__), "w") do |file|
+  File.open(File.expand_path("../lib/octicons_v2_helper/version.rb", __FILE__), "w") do |file|
     file.puts out
   end
 
-  ["octicons_helper.gemspec", "Gemfile"].each do |filename|
+  ["octicons_v2_helper.gemspec", "Gemfile"].each do |filename|
     gs = File.read(File.expand_path("../#{filename}", __FILE__))
     File.open(File.expand_path("../#{filename}", __FILE__), "w") do |file|
       file.puts gs.gsub(/"octicons_v2", "[^"]+"/, "\"octicons_v2\", \"#{args[:v]}\"")

--- a/lib/octicons_helper/lib/octicons_helper.rb
+++ b/lib/octicons_helper/lib/octicons_helper.rb
@@ -1,3 +1,0 @@
-require "octicons_helper/version"
-require "octicons_helper/helper"
-require "octicons_helper/railtie" if defined?(Rails)

--- a/lib/octicons_helper/lib/octicons_helper/railtie.rb
+++ b/lib/octicons_helper/lib/octicons_helper/railtie.rb
@@ -1,9 +1,0 @@
-require "rails"
-
-module OcticonsHelper
-  class Railtie < Rails::Railtie
-    initializer "octicons_helper.helper" do
-      ActionView::Base.send :include, OcticonsHelper
-    end
-  end
-end

--- a/lib/octicons_helper/lib/octicons_v2_helper.rb
+++ b/lib/octicons_helper/lib/octicons_v2_helper.rb
@@ -1,0 +1,3 @@
+require "octicons_v2_helper/version"
+require "octicons_v2_helper/helper"
+require "octicons_v2_helper/railtie" if defined?(Rails)

--- a/lib/octicons_helper/lib/octicons_v2_helper/helper.rb
+++ b/lib/octicons_helper/lib/octicons_v2_helper/helper.rb
@@ -1,14 +1,14 @@
-require "octicons"
+require "octicons_v2"
 require "action_view"
 
-module OcticonsHelper
+module OcticonsV2Helper
 
   include ActionView::Helpers::TagHelper
 
-  def octicon(symbol, options = {})
+  def octicon_v2(symbol, options = {})
     return "" if symbol.nil?
 
-    icon = Octicons::Octicon.new(symbol, options)
+    icon = OcticonsV2::OcticonV2.new(symbol, options)
     content_tag(:svg, icon.path.html_safe, icon.options) # rubocop:disable Rails/OutputSafety
   end
 end

--- a/lib/octicons_helper/lib/octicons_v2_helper/railtie.rb
+++ b/lib/octicons_helper/lib/octicons_v2_helper/railtie.rb
@@ -1,0 +1,9 @@
+require "rails"
+
+module OcticonsV2Helper
+  class Railtie < Rails::Railtie
+    initializer "octicons_v2_helper.helper" do
+      ActionView::Base.send :include, OcticonsV2Helper
+    end
+  end
+end

--- a/lib/octicons_helper/lib/octicons_v2_helper/version.rb
+++ b/lib/octicons_helper/lib/octicons_v2_helper/version.rb
@@ -1,3 +1,3 @@
-module Octicons
+module OcticonsV2Helper
   VERSION = "9.4.0".freeze
 end

--- a/lib/octicons_helper/octicons_v2_helper.gemspec
+++ b/lib/octicons_helper/octicons_v2_helper.gemspec
@@ -1,8 +1,8 @@
-require File.expand_path("../lib/octicons_helper/version", __FILE__)
+require File.expand_path("../lib/octicons_v2_helper/version", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "octicons_v2_helper"
-  s.version     = OcticonsHelper::VERSION
+  s.version     = OcticonsV2Helper::VERSION
   s.summary     = "Octicons rails helper"
   s.description = "A rails helper that makes including svg Octicons simple."
   s.authors     = ["GitHub Inc."]

--- a/lib/octicons_helper/test/helper.rb
+++ b/lib/octicons_helper/test/helper.rb
@@ -1,4 +1,4 @@
 require "minitest/autorun"
-require "octicons_helper"
+require "octicons_v2_helper"
 
-include OcticonsHelper
+include OcticonsV2Helper

--- a/lib/octicons_helper/test/octicons_helper_test.rb
+++ b/lib/octicons_helper/test/octicons_helper_test.rb
@@ -1,21 +1,21 @@
 require_relative "./helper"
 
-describe OcticonsHelper do
+describe OcticonsV2Helper do
   describe "rendering" do
     it "renders nothing when no symbol is passed in" do
-      assert_equal "", octicon(nil)
+      assert_equal "", octicon_v2(nil)
     end
 
     it "renders the svg" do
-      assert_match /<svg.*octicon-x.*><path.*\/><\/svg>/, octicon("x")
+      assert_match /<svg.*octicon-x.*><path.*\/><\/svg>/, octicon_v2("x")
     end
 
     it "has a path" do
-      assert_match /<path/, octicon("alert")
+      assert_match /<path/, octicon_v2("alert")
     end
 
     it "adds html attributes to output" do
-      assert_match /foo="bar"/, octicon("alert", foo: "bar")
+      assert_match /foo="bar"/, octicon_v2("alert", foo: "bar")
     end
   end
 end


### PR DESCRIPTION
This PR adds temporary name spacing to the Ruby libraries so we can use them alongside v1 in the interim.

cc @colebemis 