### PR TITLE
Fixes failing typed component

### DIFF
--- a/lib/octicons_react/ts-tests/index.tsx
+++ b/lib/octicons_react/ts-tests/index.tsx
@@ -15,6 +15,8 @@ function Icon({boom}: {boom: boolean}): React.ReactNode {
   return <Octicon icon={boom ? Zap : Beaker} />
 }
 
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+
 function OcticonByName({name, ...props}: {name: keyof iconsByName} & Omit<OcticonProps, 'icon'>): React.ReactElement {
   return <Octicon {...props} icon={getIconByName(name)} />
 }

--- a/lib/octicons_react/ts-tests/index.tsx
+++ b/lib/octicons_react/ts-tests/index.tsx
@@ -74,6 +74,10 @@ const CirclesIcon = createIcon(
   [30, 10]
 )
 
-export function CirclesOcticon(props: OcticonProps) {
+export function CirclesOcticon(props: Omit<OcticonProps, 'icon'>) {
   return <Octicon {...props} icon={CirclesIcon} />
+}
+
+function TestCirclesOcticon(): React.ReactElement {
+  return <CirclesOcticon />
 }

--- a/lib/octicons_react/ts-tests/index.tsx
+++ b/lib/octicons_react/ts-tests/index.tsx
@@ -15,7 +15,7 @@ function Icon({boom}: {boom: boolean}): React.ReactNode {
   return <Octicon icon={boom ? Zap : Beaker} />
 }
 
-function OcticonByName({name, ...props}: {name: keyof iconsByName} & OcticonProps): React.ReactNode {
+function OcticonByName({name, ...props}: {name: keyof iconsByName} & Omit<OcticonProps, 'icon'>): React.ReactElement {
   return <Octicon {...props} icon={getIconByName(name)} />
 }
 

--- a/lib/octicons_react/ts-tests/index.tsx
+++ b/lib/octicons_react/ts-tests/index.tsx
@@ -21,6 +21,10 @@ function OcticonByName({name, ...props}: {name: keyof iconsByName} & Omit<Octico
   return <Octicon {...props} icon={getIconByName(name)} />
 }
 
+function TestOcticonsByName(): React.ReactElement {
+  return <OcticonByName name="zap" />
+}
+
 // Unfortunately, `Object.keys` returns `string[]` unconditionally;
 // see https://github.com/Microsoft/TypeScript/pull/13971 &
 // https://github.com/Microsoft/TypeScript/issues/12870 for details.


### PR DESCRIPTION
The function fails in practice:
ReactElement is the correct typing for returning a react element.
```sh
JSX element type 'ReactNode' is not a constructor function for JSX elements.
```

`icon` should be left out of props here because this component overrides `icon` prop by default.
It also fails in practice because `OcticonProps` requires `icon`.
```sh
Property 'icon' is missing in type props but required in type OcticonProps
```
Another option is pass `OcticonProps` as a partial to make `icon` optional. `Partial<OcticonProps>`