### PR TITLE
Update React package to support 24px icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,67 @@
+# Unreleased
+
+## React
+
+- Icon components (e.g. `AlertIcon`, `ArrowRightIcon`, etc.) now accept `size`, `ariaLabel`, `verticalAlign`, and `className` props and can be used on their own. No need to pass them to the `Octicon` component.
+
+  ```jsx
+  // Both ways work now:
+  <Octicon icon={AlertIcon} size={24} />
+  <AlertIcon size={24} />
+  ```
+
+- Icon components will now choose the best SVG icon to render based on the `size` passed in.
+
+### BREAKING CHANGES 💥
+
+- All icon component names now include `Icon` at the end (e.g. `Alert` → `AlertIcon`).
+
+- `Octicon` no longer accepts `width` or `height` props. Use the `size` prop instead. In cases where the width and height of an icon are not equal (e.g. logos), the height will be set to the value of the `size` prop and the `width` will be scaled proportionally.
+
+- Setting `verticalAlign="top"` on the `Octicon` component or any icon component will now apply a `vertical-align: top;` style to the `<svg>`. Previously, we were translating "top" to "text-top." So setting `verticalAlign="top"` would apply a `vertical-align: text-top;` style to the `<svg>`. If you want a vertical alignment of "text-top," set the `verticalAlign` prop to `"text-top"`.
+
+- Custom icon components passed to the `Octicon` component now need to render the entire `<svg>`, not just the `<path>`.
+
+```diff
+function CirclesIcon() {
+  return (
+-   <React.Fragment>
++   <svg viewBox="0 0 30 10" width="30" height="10">
+      <circle r={5} cx={5} cy={5}/>
+      <circle r={5} cx={15} cy={5}/>
+      <circle r={5} cx={25} cy={5}/>
+-   </React.Fragment>
++   </svg>
+  )
+}
+
+- CirclesIcon.size = [30, 10]
+```
+
 # 9.6.0
 
 ## Features
+
 - New icon `north-star` https://github.com/primer/octicons/pull/380
 
 # 9.5.0
 
 ## Features
+
 - New icon `internal-repo` https://github.com/primer/octicons/pull/375
 
 # 9.4.0
 
-##  Features
+## Features
+
 - New icons `heart-outline` `infinity` `line-arrow-up` `line-arrow-down` `line-arrow-right` `line-arrow-left` https://github.com/primer/octicons/pull/365
 
 ## Chores
-- Contributing docs updates and issue template updates #367 
+
+- Contributing docs updates and issue template updates #367
 
 ## Bugs
+
 - Update `heart` glyphs removing extra points https://github.com/primer/octicons/pull/365
 
 # 9.3.1
@@ -36,7 +81,7 @@
 
 ### 🚀 New features
 
- - [x] New icons for save/unsave and primitive dot stroke https://github.com/primer/octicons/pull/351 @ashygee @colinkeany
+- [x] New icons for save/unsave and primitive dot stroke https://github.com/primer/octicons/pull/351 @ashygee @colinkeany
 
 ### 🧽 Chores
 
@@ -63,6 +108,7 @@
 # 9.0.0
 
 ### 💥 Breaking changes
+
 - [x] Rename `octicons` to `@primer/octicons` https://github.com/primer/octicons/pull/311
 - [x] Rename `@githubprimer/octicons-react` to `@primer/octicons-react` https://github.com/primer/octicons/pull/311
 
@@ -80,22 +126,27 @@
 # 8.4.2
 
 ### :art: Enhancement
+
 - Thumbs up/down icons needed some vector improvements. https://github.com/primer/octicons/pull/287
 
 ### :bug: Bug Fix
+
 - Node package missing `build/build.css` file. https://github.com/primer/octicons/pull/292
 
 # 8.4.1
 
 ### :bug: Bug Fix
+
 - Rollup files missing from octicons react package https://github.com/primer/octicons/issues/282
 
 # 8.4.0
 
 ### :house: Internal
+
 - Using Actions to build and deploy Octicons https://github.com/primer/octicons/pull/276
 
 #### Committers: 1
+
 - Jon Rohan ([jonrohan](https://github.com/jonrohan))
 
 # 8.3.0
@@ -345,7 +396,6 @@ Removes
 
 - `screen-normal`
 - `screen-full`
-
 
 ### 3.1.0 (August 13, 2015)
 

--- a/lib/octicons_gem/lib/octicons_v2/version.rb
+++ b/lib/octicons_gem/lib/octicons_v2/version.rb
@@ -1,3 +1,3 @@
 module OcticonsV2
-  VERSION = "9.4.0".freeze
+  VERSION = "10.0.0".freeze
 end

--- a/lib/octicons_helper/Gemfile
+++ b/lib/octicons_helper/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "octicons_v2", "9.4.0"
+gem "octicons_v2", "10.0.0"
 gem "rails"
 
 group :development, :test do

--- a/lib/octicons_helper/lib/octicons_v2_helper/version.rb
+++ b/lib/octicons_helper/lib/octicons_v2_helper/version.rb
@@ -1,3 +1,3 @@
 module OcticonsV2Helper
-  VERSION = "9.4.0".freeze
+  VERSION = "10.0.0".freeze
 end

--- a/lib/octicons_helper/octicons_v2_helper.gemspec
+++ b/lib/octicons_helper/octicons_v2_helper.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "octicons_v2", "9.4.0"
+  s.add_dependency "octicons_v2", "10.0.0"
   s.add_dependency "rails"
 end

--- a/lib/octicons_jekyll/Gemfile
+++ b/lib/octicons_jekyll/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "octicons_v2", "9.4.0"
+gem "octicons_v2", "10.0.0"
 
 group :development, :test do
   gem "minitest"

--- a/lib/octicons_node/package-lock.json
+++ b/lib/octicons_node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/octicons-v2",
-  "version": "9.4.0",
+  "version": "10.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lib/octicons_node/package.json
+++ b/lib/octicons_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/octicons-v2",
-  "version": "9.4.0",
+  "version": "10.0.0",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",
   "author": "GitHub Inc.",

--- a/lib/octicons_react/package-lock.json
+++ b/lib/octicons_react/package-lock.json
@@ -11778,9 +11778,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "ua-parser-js": {

--- a/lib/octicons_react/package-lock.json
+++ b/lib/octicons_react/package-lock.json
@@ -7635,7 +7635,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -7908,6 +7909,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -8663,7 +8665,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -9258,6 +9261,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9480,19 +9484,8 @@
     "react-is": {
       "version": "16.13.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
-      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
-    },
-    "react-test-renderer": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.0.tgz",
-      "integrity": "sha512-NQ2S9gdMUa7rgPGpKGyMcwl1d6D9MCF0lftdI3kts6kkiX+qvpC955jNjAZXlIDTjnN9jwFI8A8XhRh/9v0spA==",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.19.0"
-      }
+      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==",
+      "dev": true
     },
     "read-pkg": {
       "version": "2.0.0",

--- a/lib/octicons_react/package-lock.json
+++ b/lib/octicons_react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/octicons-v2-react",
-  "version": "9.4.0",
+  "version": "10.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lib/octicons_react/package-lock.json
+++ b/lib/octicons_react/package-lock.json
@@ -127,6 +127,24 @@
         }
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
+      "integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
@@ -206,6 +224,319 @@
         "prop-types": "^15.6.1"
       }
     },
+    "@jest/types": {
+      "version": "25.2.6",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.6.tgz",
+      "integrity": "sha512-myJTTV37bxK7+3NgKc4Y/DlQ5q92/NOwZsZ+Uch7OXdElxOg61QYc72fPYNAjlvbnJ2YvbXLamIsa9tj48BmyQ==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/dom": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.2.1.tgz",
+      "integrity": "sha512-xIGoHlQ2ZiEL1dJIFKNmLDypzYF+4OJTTASRctl/aoIDaS5y/pRVHRigoqvPUV11mdJoR71IIgi/6UviMgyz4g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__dom": "^7.0.0",
+        "aria-query": "^4.0.2",
+        "dom-accessibility-api": "^0.4.2",
+        "pretty-format": "^25.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "aria-query": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.0.2.tgz",
+          "integrity": "sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.4",
+            "@babel/runtime-corejs3": "^7.7.4"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.6.tgz",
+          "integrity": "sha512-DEiWxLBaCHneffrIT4B+TpMvkV9RNvvJrd3lY9ew1CEQobDzEXmYT1mg0hJhljZty7kCc10z13ohOFAE8jrUDg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.2.6",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.3.0.tgz",
+      "integrity": "sha512-Cdhpc3BHL888X55qBNyra9eM0UG63LCm/FqCWTa1Ou/0MpsUbQTM9vW1NU6/jBQFoSLgkFfDG5XVpm2V0dOm/A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.0.2",
+        "chalk": "^3.0.0",
+        "css": "^2.2.4",
+        "css.escape": "^1.5.1",
+        "jest-diff": "^25.1.0",
+        "jest-matcher-utils": "^25.1.0",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.2.6.tgz",
+          "integrity": "sha512-KuadXImtRghTFga+/adnNrv9s61HudRMR7gVSbP35UKZdn4IK2/0N0PpGZIqtmllK9aUyye54I3nu28OYSnqOg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.2.6"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "25.2.7",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.2.7.tgz",
+          "integrity": "sha512-jNYmKQPRyPO3ny0KY1I4f0XW4XnpJ3Nx5ovT4ik0TYDOYzuXJW40axqOyS61l/voWbVT9y9nZ1THL1DlpaBVpA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "jest-diff": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.2.6"
+          }
+        },
+        "pretty-format": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.6.tgz",
+          "integrity": "sha512-DEiWxLBaCHneffrIT4B+TpMvkV9RNvvJrd3lY9ew1CEQobDzEXmYT1mg0hJhljZty7kCc10z13ohOFAE8jrUDg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.2.6",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.0.2.tgz",
+      "integrity": "sha512-YT6Mw0oJz7R6vlEkmo1FlUD+K15FeXApOB5Ffm9zooFVnrwkt00w18dUJFMOh1yRp9wTdVRonbor7o4PIpFCmA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@testing-library/dom": "^7.1.0",
+        "@types/testing-library__react": "^10.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -217,6 +548,129 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.1.tgz",
+      "integrity": "sha512-msra1bCaAeEdkSyA0CZ6gW1ukMIvZ5YoJkdXw/qhQdsuuDlFTcEUrUw8CLCPt2rVRUfXlClVvK2gvPs9IokZaA==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^25.2.1",
+        "pretty-format": "^25.2.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.2.6.tgz",
+          "integrity": "sha512-KuadXImtRghTFga+/adnNrv9s61HudRMR7gVSbP35UKZdn4IK2/0N0PpGZIqtmllK9aUyye54I3nu28OYSnqOg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.2.6"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.6.tgz",
+          "integrity": "sha512-DEiWxLBaCHneffrIT4B+TpMvkV9RNvvJrd3lY9ew1CEQobDzEXmYT1mg0hJhljZty7kCc10z13ohOFAE8jrUDg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.2.6",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "@types/json-schema": {
       "version": "7.0.4",
@@ -245,6 +699,149 @@
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
       }
+    },
+    "@types/react-dom": {
+      "version": "16.9.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.6.tgz",
+      "integrity": "sha512-S6ihtlPMDotrlCJE9ST1fRmYrQNNwfgL61UB4I1W7M6kPulUKx9fXAleW5zpdIjUQ4fTaaog8uERezjsGUj9HQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/testing-library__dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-7.0.1.tgz",
+      "integrity": "sha512-WokGRksRJb3Dla6h02/0/NNHTkjsj4S8aJZiwMj/5/UL8VZ1iCe3H8SHzfpmBeH8Vp4SPRT8iC2o9kYULFhDIw==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "^25.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.6.tgz",
+          "integrity": "sha512-DEiWxLBaCHneffrIT4B+TpMvkV9RNvvJrd3lY9ew1CEQobDzEXmYT1mg0hJhljZty7kCc10z13ohOFAE8jrUDg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.2.6",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
+      }
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.0.3.tgz",
+      "integrity": "sha512-NdbKc6yseg6uq4UJFwimPws0iwsGugVbPoOTP2EH+PJMJKiZsoSg5F2H3XYweOyytftCOuIMuXifBUrF9CSvaQ==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
+    },
+    "@types/testing-library__react": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-10.0.1.tgz",
+      "integrity": "sha512-RbDwmActAckbujLZeVO/daSfdL1pnjVqas25UueOkAY5r7vriavWf0Zqg7ghXMHa8ycD/kLkv8QOj31LmSYwww==",
+      "dev": true,
+      "requires": {
+        "@types/react-dom": "*",
+        "@types/testing-library__dom": "*",
+        "pretty-format": "^25.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.6.tgz",
+          "integrity": "sha512-DEiWxLBaCHneffrIT4B+TpMvkV9RNvvJrd3lY9ew1CEQobDzEXmYT1mg0hJhljZty7kCc10z13ohOFAE8jrUDg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.2.6",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
+      }
+    },
+    "@types/yargs": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
+      "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "1.13.0",
@@ -2886,6 +3483,12 @@
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
       "dev": true
     },
+    "core-js-pure": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
+      "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2984,6 +3587,32 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
+    },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true
     },
     "cssom": {
@@ -3263,6 +3892,12 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "diff-sequences": {
+      "version": "25.2.6",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+      "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+      "dev": true
+    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -3282,6 +3917,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.3.tgz",
+      "integrity": "sha512-JZ8iPuEHDQzq6q0k7PKMGbrIdsgBB7TRrtVOUm4nSMCExlg5qQG4KXWTH2k90yggjM4tTumRGwTKJSldMzKyLA==",
+      "dev": true
     },
     "dom-walk": {
       "version": "0.1.1",
@@ -5594,6 +6235,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -7480,6 +8127,12 @@
         "dom-walk": "^0.1.0"
       }
     },
+    "min-indent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+      "dev": true
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -9315,6 +9968,16 @@
         }
       }
     },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -10636,6 +11299,15 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -26,9 +26,6 @@
     "react",
     "primer"
   ],
-  "dependencies": {
-    "prop-types": "^15.6.1"
-  },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.3.0",
     "@testing-library/react": "^10.0.2",
@@ -45,7 +42,6 @@
     "primer-react": "0.0.6-alpha.1",
     "react": "^16.4.0",
     "react-dom": "^16.4.1",
-    "react-test-renderer": "^16.4.1",
     "rollup": "^0.62.0",
     "rollup-plugin-babel": "^3.0.5",
     "rollup-plugin-commonjs": "^9.1.3",

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -30,6 +30,8 @@
     "prop-types": "^15.6.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.3.0",
+    "@testing-library/react": "^10.0.2",
     "@types/react": "^16.4.6",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/octicons-v2-react",
-  "version": "9.4.0",
+  "version": "10.0.0",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",
   "author": "GitHub, Inc.",

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -45,7 +45,7 @@
     "rollup": "^0.62.0",
     "rollup-plugin-babel": "^3.0.5",
     "rollup-plugin-commonjs": "^9.1.3",
-    "typescript": "^2.9.2"
+    "typescript": "^3.7.5"
   },
   "peerDependencies": {
     "react": ">=15"

--- a/lib/octicons_react/script/build.js
+++ b/lib/octicons_react/script/build.js
@@ -41,57 +41,9 @@ function writeIcons(file) {
   const count = icons.length
   const code = `${GENERATED_HEADER}
 import React from 'react'
+import getSvgProps from '../get-svg-props'
 
 ${icons.map(({code}) => code).join('\n')}
-
-function closestNaturalHeight(naturalHeights, height) {
-  return naturalHeights
-    .map(naturalHeight => parseInt(naturalHeight, 10))
-    .reduce(
-      (acc, naturalHeight) => (naturalHeight <= height ? naturalHeight : acc),
-      naturalHeights[0]
-    )
-}
-
-const sizeMap = {
-  small: 16,
-  medium: 32,
-  large: 64
-}
-
-function getSvgProps({
-  ariaLabel,
-  className,
-  size,
-  verticalAlign,
-  svgDataByHeight
-}) {
-  const height = sizeMap[size] || size
-  const naturalHeight = closestNaturalHeight(
-    Object.keys(svgDataByHeight),
-    height
-  )
-  const naturalWidth = svgDataByHeight[naturalHeight].width
-  const width = height * (naturalWidth / naturalHeight)
-  const path = svgDataByHeight[naturalHeight].path
-
-  return {
-    'aria-hidden': ariaLabel ? 'false' : 'true',
-    'aria-label': ariaLabel,
-    role: 'img',
-    className,
-    viewBox: \`0 0 $\{naturalWidth} $\{naturalHeight}\`,
-    width,
-    height,
-    fill: 'currentColor',
-    style: {
-      display: 'inline-block',
-      userSelect: 'none',
-      verticalAlign
-    },
-    dangerouslySetInnerHTML: { __html: path }
-  }
-}
 
 const iconsByName = {
   ${icons.map(({key, name}) => `'${key}': ${name}`).join(',\n  ')}

--- a/lib/octicons_react/script/build.js
+++ b/lib/octicons_react/script/build.js
@@ -122,8 +122,8 @@ type Size = 'small' | 'medium' | 'large'
 interface IconProps {
   ariaLabel?: string
   className?: string
-  size: number | Size
-  verticalAlign: 'middle' | 'text-bottom' | 'text-top' | 'top' | 'unset'
+  size?: number | Size
+  verticalAlign?: 'middle' | 'text-bottom' | 'text-top' | 'top' | 'unset'
 }
 
 type Icon = React.FC<IconProps>

--- a/lib/octicons_react/script/build.js
+++ b/lib/octicons_react/script/build.js
@@ -9,37 +9,29 @@ const typesFile = join(srcDir, 'icons.d.ts')
 
 const GENERATED_HEADER = '/* THIS FILE IS GENERATED. DO NOT EDIT IT. */'
 
-const DEFAULT_HEIGHT = '16'
-
-function CamelCase(str) {
+function pascalCase(str) {
   return str.replace(/(^|-)([a-z])/g, (_, __, c) => c.toUpperCase())
 }
 
-const octiconNames = [...Object.entries(octicons)]
-
-const icons = octiconNames
-  // Temporarily filter out icons without 16px SVGs until we update the library
-  // to handle mupltiple SVGs per icon.
-  .filter(([, octicon]) => DEFAULT_HEIGHT in octicon.heights)
+const icons = Object.entries(octicons)
   .map(([key, octicon]) => {
-    const name = CamelCase(key)
-    const width = octicon.heights[DEFAULT_HEIGHT].width
-    const height = parseInt(DEFAULT_HEIGHT)
-    const path = octicon.heights[DEFAULT_HEIGHT].path
-    // convert attributes like fill-rule into JSX equivalents, e.g. fillRule
-    const svg = path.replace(/([a-z]+)-([a-z]+)=/g, (_, a, b) => `${a}${CamelCase(b)}=`)
-    const type = `Icon<${width}, ${height}>`
-    const code = `function ${name}() {
-  return <React.Fragment>${svg}</React.Fragment>
+    const name = pascalCase(key)
+    const code = `function ${name}(props) {
+  const svgDataByHeight = ${JSON.stringify(octicon.heights)}
+  return <svg {...getSvgProps({...props, svgDataByHeight})} />
 }
-${name}.size = [${width}, ${height}]
+
+${name}.defaultProps = {
+  className: 'octicon',
+  size: 16,
+  verticalAlign: 'text-bottom'
+}
 `
 
     return {
       key,
       name,
       octicon,
-      type,
       code
     }
   })
@@ -51,6 +43,55 @@ function writeIcons(file) {
 import React from 'react'
 
 ${icons.map(({code}) => code).join('\n')}
+
+function closestNaturalHeight(naturalHeights, height) {
+  return naturalHeights
+    .map(naturalHeight => parseInt(naturalHeight, 10))
+    .reduce(
+      (acc, naturalHeight) => (naturalHeight <= height ? naturalHeight : acc),
+      naturalHeights[0]
+    )
+}
+
+const sizeMap = {
+  small: 16,
+  medium: 32,
+  large: 64
+}
+
+function getSvgProps({
+  ariaLabel,
+  className,
+  size,
+  verticalAlign,
+  svgDataByHeight
+}) {
+  const height = sizeMap[size] || size
+  const naturalHeight = closestNaturalHeight(
+    Object.keys(svgDataByHeight),
+    height
+  )
+  const naturalWidth = svgDataByHeight[naturalHeight].width
+  const width = height * (naturalWidth / naturalHeight)
+  const path = svgDataByHeight[naturalHeight].path
+
+  return {
+    'aria-hidden': ariaLabel ? 'false' : 'true',
+    'aria-label': ariaLabel,
+    role: 'img',
+    className,
+    viewBox: \`0 0 $\{naturalWidth} $\{naturalHeight}\`,
+    width,
+    height,
+    fill: 'currentColor',
+    style: {
+      display: 'inline-block',
+      userSelect: 'none',
+      verticalAlign
+    },
+    dangerouslySetInnerHTML: { __html: path }
+  }
+}
 
 const iconsByName = {
   ${icons.map(({key, name}) => `'${key}': ${name}`).join(',\n  ')}
@@ -76,15 +117,21 @@ function writeTypes(file) {
   const code = `${GENERATED_HEADER}
 import * as React from 'react'
 
-type Icon<
-  W extends number = number,
-  H extends number = number
-> = React.SFC<{}> & { size: [W, H] };
+type Size = 'small' | 'medium' | 'large'
 
-${icons.map(({name, type}) => `declare const ${name}: ${type}`).join('\n')}
+interface IconProps {
+  ariaLabel?: string
+  className?: string
+  size: number | Size
+  verticalAlign: 'middle' | 'text-bottom' | 'text-top' | 'top' | 'unset'
+}
+
+type Icon = React.FC<IconProps>
+
+${icons.map(({name}) => `declare const ${name}: Icon`).join('\n')}
 
 type iconsByName = {
-  ${icons.map(({key, type}) => `'${key}': ${type}`).join(',\n  ')}
+  ${icons.map(({key}) => `'${key}': Icon`).join(',\n  ')}
 }
 declare const iconsByName: iconsByName
 

--- a/lib/octicons_react/script/build.js
+++ b/lib/octicons_react/script/build.js
@@ -15,7 +15,7 @@ function pascalCase(str) {
 
 const icons = Object.entries(octicons)
   .map(([key, octicon]) => {
-    const name = pascalCase(key)
+    const name = `${pascalCase(key)}Icon`
     const code = `function ${name}(props) {
   const svgDataByHeight = ${JSON.stringify(octicon.heights)}
   return <svg {...getSvgProps({...props, svgDataByHeight})} />

--- a/lib/octicons_react/src/__tests__/__snapshots__/octicon.js.snap
+++ b/lib/octicons_react/src/__tests__/__snapshots__/octicon.js.snap
@@ -1,22 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Octicon> outputs <svg> 1`] = `
+exports[`An icon component matches snapshot 1`] = `
 <svg
   aria-hidden="true"
-  className="octicon"
-  height={16}
+  class="octicon"
+  fill="currentColor"
+  height="16"
   role="img"
-  style={
-    Object {
-      "display": "inline-block",
-      "fill": "currentColor",
-      "userSelect": "none",
-      "verticalAlign": "text-bottom",
-    }
-  }
+  style="display: inline-block; user-select: none; vertical-align: text-bottom;"
   viewBox="0 0 16 16"
-  width={16}
+  width="16"
 >
-  <path />
+  <path
+    clip-rule="evenodd"
+    d="M8.22048 1.75358C8.1263 1.57738 7.87369 1.57738 7.77951 1.75359L1.69787 13.1321C1.60886 13.2987 1.72953 13.5 1.91835 13.5H14.0816C14.2705 13.5 14.3911 13.2987 14.3021 13.1321L8.22048 1.75358ZM6.45662 1.04652C7.11588 -0.186933 8.88412 -0.186935 9.54338 1.04652L15.625 12.4251C16.2481 13.5908 15.4034 15 14.0816 15H1.91835C0.596554 15 -0.248093 13.5908 0.374974 12.4251L6.45662 1.04652ZM9 11C9 11.5523 8.55229 12 8 12C7.44772 12 7 11.5523 7 11C7 10.4477 7.44772 10 8 10C8.55229 10 9 10.4477 9 11ZM8.75 5.75C8.75 5.33579 8.41421 5 8 5C7.58579 5 7.25 5.33579 7.25 5.75V8.25C7.25 8.66421 7.58579 9 8 9C8.41421 9 8.75 8.66421 8.75 8.25V5.75Z"
+    fill-rule="evenodd"
+  />
 </svg>
 `;

--- a/lib/octicons_react/src/__tests__/all.js
+++ b/lib/octicons_react/src/__tests__/all.js
@@ -1,14 +1,14 @@
-import {Alert, X, getIconByName, iconsByName} from '../'
+import {AlertIcon, XIcon, getIconByName, iconsByName} from '../'
 
 describe('import {getIconByName}', () => {
   it('gets named icons', () => {
     const Icon = getIconByName('x')
-    expect(Icon).toEqual(X)
+    expect(Icon).toEqual(XIcon)
   })
 })
 
 describe('import {iconsByName}', () => {
   it('gets all the icons', () => {
-    expect(iconsByName.alert).toEqual(Alert)
+    expect(iconsByName.alert).toEqual(AlertIcon)
   })
 })

--- a/lib/octicons_react/src/__tests__/octicon.js
+++ b/lib/octicons_react/src/__tests__/octicon.js
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom'
 import {render} from '@testing-library/react'
 import React from 'react'
-import Octicon, {Alert} from '../index'
+import Octicon, {AlertIcon} from '../index'
 
 describe('Octicon component', () => {
   it('throws an error without a single child or icon prop', () => {
@@ -13,7 +13,7 @@ describe('Octicon component', () => {
 
   it('passes props to icon prop', () => {
     const {container} = render(
-      <Octicon ariaLabel="icon" className="foo" size={20} verticalAlign="middle" icon={Alert} />
+      <Octicon ariaLabel="icon" className="foo" size={20} verticalAlign="middle" icon={AlertIcon} />
     )
     expect(container.querySelector('svg')).toHaveAttribute('class', 'foo')
     expect(container.querySelector('svg')).toHaveAttribute('width', '20')
@@ -24,7 +24,7 @@ describe('Octicon component', () => {
   it('passes props to icon as child', () => {
     const {container} = render(
       <Octicon ariaLabel="icon" className="foo" size={20} verticalAlign="middle">
-        <Alert />
+        <AlertIcon />
       </Octicon>
     )
     expect(container.querySelector('svg')).toHaveAttribute('aria-label', 'icon')
@@ -37,60 +37,60 @@ describe('Octicon component', () => {
 
 describe('An icon component', () => {
   it('matches snapshot', () => {
-    const {container} = render(<Alert />)
+    const {container} = render(<AlertIcon />)
     expect(container.querySelector('svg')).toMatchSnapshot()
   })
 
   it('sets aria-hidden="false" if ariaLabel prop is present', () => {
-    const {container} = render(<Alert ariaLabel="icon" />)
+    const {container} = render(<AlertIcon ariaLabel="icon" />)
     expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'false')
     expect(container.querySelector('svg')).toHaveAttribute('aria-label', 'icon')
   })
 
   it('respects the className prop', () => {
-    const {container} = render(<Alert className="foo" />)
+    const {container} = render(<AlertIcon className="foo" />)
     expect(container.querySelector('svg')).toHaveAttribute('class', 'foo')
   })
 
   it('respects the verticalAlign prop', () => {
-    const {container} = render(<Alert verticalAlign="middle" />)
+    const {container} = render(<AlertIcon verticalAlign="middle" />)
     expect(container.querySelector('svg')).toHaveStyle({verticalAlign: 'middle'})
   })
 
   describe('size props', () => {
     it('respects size="small"', () => {
-      const {container} = render(<Alert size="small" />)
+      const {container} = render(<AlertIcon size="small" />)
       expect(container.querySelector('svg')).toHaveAttribute('width', '16')
       expect(container.querySelector('svg')).toHaveAttribute('height', '16')
     })
 
     it('respects size="medium"', () => {
-      const {container} = render(<Alert size="medium" />)
+      const {container} = render(<AlertIcon size="medium" />)
       expect(container.querySelector('svg')).toHaveAttribute('width', '32')
       expect(container.querySelector('svg')).toHaveAttribute('height', '32')
     })
 
     it('respects size="large"', () => {
-      const {container} = render(<Alert size="large" />)
+      const {container} = render(<AlertIcon size="large" />)
       expect(container.querySelector('svg')).toHaveAttribute('width', '64')
       expect(container.querySelector('svg')).toHaveAttribute('height', '64')
     })
 
     it('respects size={number}', () => {
-      const {container} = render(<Alert size={128} />)
+      const {container} = render(<AlertIcon size={128} />)
       expect(container.querySelector('svg')).toHaveAttribute('width', '128')
       expect(container.querySelector('svg')).toHaveAttribute('height', '128')
     })
 
     it('chooses the correct SVG given a size <24', () => {
-      const {container} = render(<Alert size={20} />)
+      const {container} = render(<AlertIcon size={20} />)
       expect(container.querySelector('svg')).toHaveAttribute('viewBox', '0 0 16 16')
       expect(container.querySelector('svg')).toHaveAttribute('width', '20')
       expect(container.querySelector('svg')).toHaveAttribute('height', '20')
     })
 
     it('chooses the correct SVG given a size >=24', () => {
-      const {container} = render(<Alert size={24} />)
+      const {container} = render(<AlertIcon size={24} />)
       expect(container.querySelector('svg')).toHaveAttribute('viewBox', '0 0 24 24')
       expect(container.querySelector('svg')).toHaveAttribute('width', '24')
       expect(container.querySelector('svg')).toHaveAttribute('height', '24')

--- a/lib/octicons_react/src/__tests__/octicon.js
+++ b/lib/octicons_react/src/__tests__/octicon.js
@@ -1,15 +1,9 @@
+import '@testing-library/jest-dom'
+import {render} from '@testing-library/react'
 import React from 'react'
-import Octicon from '../index'
-import renderer from 'react-test-renderer'
+import Octicon, {Alert} from '../index'
 
-const render = el => renderer.create(el).toJSON()
-
-// set a default child; this is essentially a shallow render helper
-const TestOcticon = ({children, ...props}) => {
-  return <Octicon {...props}>{children || <path />}</Octicon>
-}
-
-describe('<Octicon>', () => {
+describe('Octicon component', () => {
   it('throws an error without a single child or icon prop', () => {
     // console.error() is ugly af in jest; mock it with a noop
     jest.spyOn(console, 'error').mockImplementation(() => jest.fn())
@@ -17,113 +11,89 @@ describe('<Octicon>', () => {
     expect(() => render(<Octicon icon={null} />)).toThrow()
   })
 
-  it('outputs <svg>', () => {
-    const rendered = render(<TestOcticon />)
-    expect(rendered).toMatchSnapshot()
-    expect(rendered.type).toEqual('svg')
+  it('passes props to icon prop', () => {
+    const {container} = render(
+      <Octicon ariaLabel="icon" className="foo" size={20} verticalAlign="middle" icon={Alert} />
+    )
+    expect(container.querySelector('svg')).toHaveAttribute('class', 'foo')
+    expect(container.querySelector('svg')).toHaveAttribute('width', '20')
+    expect(container.querySelector('svg')).toHaveAttribute('height', '20')
+    expect(container.querySelector('svg')).toHaveStyle({verticalAlign: 'middle'})
+  })
+
+  it('passes props to icon as child', () => {
+    const {container} = render(
+      <Octicon ariaLabel="icon" className="foo" size={20} verticalAlign="middle">
+        <Alert />
+      </Octicon>
+    )
+    expect(container.querySelector('svg')).toHaveAttribute('aria-label', 'icon')
+    expect(container.querySelector('svg')).toHaveAttribute('class', 'foo')
+    expect(container.querySelector('svg')).toHaveAttribute('width', '20')
+    expect(container.querySelector('svg')).toHaveAttribute('height', '20')
+    expect(container.querySelector('svg')).toHaveStyle({verticalAlign: 'middle'})
+  })
+})
+
+describe('An icon component', () => {
+  it('matches snapshot', () => {
+    const {container} = render(<Alert />)
+    expect(container.querySelector('svg')).toMatchSnapshot()
+  })
+
+  it('sets aria-hidden="false" if ariaLabel prop is present', () => {
+    const {container} = render(<Alert ariaLabel="icon" />)
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'false')
+    expect(container.querySelector('svg')).toHaveAttribute('aria-label', 'icon')
   })
 
   it('respects the className prop', () => {
-    expect(render(<TestOcticon className="foo" />).props.className).toEqual('foo')
+    const {container} = render(<Alert className="foo" />)
+    expect(container.querySelector('svg')).toHaveAttribute('class', 'foo')
   })
 
   it('respects the verticalAlign prop', () => {
-    expect(render(<TestOcticon verticalAlign="middle" />).props.style.verticalAlign).toEqual('middle')
-    expect(render(<TestOcticon verticalAlign="text-bottom" />).props.style.verticalAlign).toEqual('text-bottom')
-    // FIXME: I have no idea why this fails!
-    // expect(render(<TestOcticon verticalAlign="text-top" />).props.style.verticalAlign).toEqual('text-top')
-    expect(render(<TestOcticon verticalAlign="top" />).props.style.verticalAlign).toEqual('text-top')
+    const {container} = render(<Alert verticalAlign="middle" />)
+    expect(container.querySelector('svg')).toHaveStyle({verticalAlign: 'middle'})
   })
 
   describe('size props', () => {
     it('respects size="small"', () => {
-      const rendered = render(<TestOcticon size="small" />)
-      expect(rendered.props.width).toEqual(16)
-      expect(rendered.props.height).toEqual(16)
+      const {container} = render(<Alert size="small" />)
+      expect(container.querySelector('svg')).toHaveAttribute('width', '16')
+      expect(container.querySelector('svg')).toHaveAttribute('height', '16')
     })
 
     it('respects size="medium"', () => {
-      const rendered = render(<TestOcticon size="medium" />)
-      expect(rendered.props.width).toEqual(32)
-      expect(rendered.props.height).toEqual(32)
+      const {container} = render(<Alert size="medium" />)
+      expect(container.querySelector('svg')).toHaveAttribute('width', '32')
+      expect(container.querySelector('svg')).toHaveAttribute('height', '32')
     })
 
     it('respects size="large"', () => {
-      const rendered = render(<TestOcticon size="large" />)
-      expect(rendered.props.width).toEqual(64)
-      expect(rendered.props.height).toEqual(64)
+      const {container} = render(<Alert size="large" />)
+      expect(container.querySelector('svg')).toHaveAttribute('width', '64')
+      expect(container.querySelector('svg')).toHaveAttribute('height', '64')
     })
 
     it('respects size={number}', () => {
-      const rendered = render(<TestOcticon size={128} />)
-      expect(rendered.props.width).toEqual(128)
-      expect(rendered.props.height).toEqual(128)
+      const {container} = render(<Alert size={128} />)
+      expect(container.querySelector('svg')).toHaveAttribute('width', '128')
+      expect(container.querySelector('svg')).toHaveAttribute('height', '128')
     })
 
-    it('respects width instead of size', () => {
-      const rendered = render(<TestOcticon width={48} />)
-      expect(rendered.props.width).toEqual(48)
-      expect(rendered.props.height).toEqual(48)
+    it('chooses the correct SVG given a size <24', () => {
+      const {container} = render(<Alert size={20} />)
+      expect(container.querySelector('svg')).toHaveAttribute('viewBox', '0 0 16 16')
+      expect(container.querySelector('svg')).toHaveAttribute('width', '20')
+      expect(container.querySelector('svg')).toHaveAttribute('height', '20')
     })
 
-    it('respects height instead of size', () => {
-      const rendered = render(<TestOcticon height={48} />)
-      expect(rendered.props.width).toEqual(48)
-      expect(rendered.props.height).toEqual(48)
-    })
-  })
-
-  describe('with <path> as child', () => {
-    it('generates a default viewBox', () => {
-      const rendered = render(<TestOcticon />)
-      expect(rendered.props.viewBox).toEqual('0 0 16 16')
-    })
-
-    it('generates default viewBox', () => {
-      const rendered = render(<TestOcticon />)
-      expect(rendered.props.viewBox).toEqual('0 0 16 16')
-    })
-  })
-
-  describe('Icon type support', () => {
-    function Icon() {
-      return <path />
-    }
-    Icon.size = [12, 20]
-
-    it('generates the right viewBox with an <Icon/> child', () => {
-      const rendered = render(
-        <Octicon>
-          <Icon />
-        </Octicon>
-      )
-      expect(rendered.props.viewBox).toEqual('0 0 12 20')
-    })
-
-    it('generates the right viewBox with icon={Icon}', () => {
-      const rendered = render(<Octicon icon={Icon} />)
-      expect(rendered.props.viewBox).toEqual('0 0 12 20')
-    })
-
-    it('generates the right viewBox with custom size', () => {
-      const rendered = render(<Octicon icon={Icon} size={40} />)
-      expect(rendered.props.viewBox).toEqual('0 0 12 20')
-      expect(rendered.props.height).toEqual(40)
-      expect(rendered.props.width).toEqual(24)
-    })
-
-    it('generates the right viewBox with custom width', () => {
-      const rendered = render(<Octicon icon={Icon} width={24} />)
-      expect(rendered.props.viewBox).toEqual('0 0 12 20')
-      expect(rendered.props.width).toEqual(24)
-      expect(rendered.props.height).toEqual(40)
-    })
-
-    it('generates the right viewBox with custom height', () => {
-      const rendered = render(<Octicon icon={Icon} height={10} />)
-      expect(rendered.props.viewBox).toEqual('0 0 12 20')
-      expect(rendered.props.width).toEqual(6)
-      expect(rendered.props.height).toEqual(10)
+    it('chooses the correct SVG given a size >=24', () => {
+      const {container} = render(<Alert size={24} />)
+      expect(container.querySelector('svg')).toHaveAttribute('viewBox', '0 0 24 24')
+      expect(container.querySelector('svg')).toHaveAttribute('width', '24')
+      expect(container.querySelector('svg')).toHaveAttribute('height', '24')
     })
   })
 })

--- a/lib/octicons_react/src/get-svg-props.js
+++ b/lib/octicons_react/src/get-svg-props.js
@@ -1,0 +1,36 @@
+const sizeMap = {
+  small: 16,
+  medium: 32,
+  large: 64
+}
+
+export default function getSvgProps({ariaLabel, className, size, verticalAlign, svgDataByHeight}) {
+  const height = sizeMap[size] || size
+  const naturalHeight = closestNaturalHeight(Object.keys(svgDataByHeight), height)
+  const naturalWidth = svgDataByHeight[naturalHeight].width
+  const width = height * (naturalWidth / naturalHeight)
+  const path = svgDataByHeight[naturalHeight].path
+
+  return {
+    'aria-hidden': ariaLabel ? 'false' : 'true',
+    'aria-label': ariaLabel,
+    role: 'img',
+    className,
+    viewBox: `0 0 ${naturalWidth} ${naturalHeight}`,
+    width,
+    height,
+    fill: 'currentColor',
+    style: {
+      display: 'inline-block',
+      userSelect: 'none',
+      verticalAlign
+    },
+    dangerouslySetInnerHTML: {__html: path}
+  }
+}
+
+function closestNaturalHeight(naturalHeights, height) {
+  return naturalHeights
+    .map(naturalHeight => parseInt(naturalHeight, 10))
+    .reduce((acc, naturalHeight) => (naturalHeight <= height ? naturalHeight : acc), naturalHeights[0])
+}

--- a/lib/octicons_react/src/index.d.ts
+++ b/lib/octicons_react/src/index.d.ts
@@ -3,23 +3,18 @@ import * as React from 'react'
 import {Icon} from './__generated__/icons'
 
 type Size = 'small' | 'medium' | 'large'
+
 export interface OcticonProps {
   ariaLabel?: string
   children?: React.ReactElement<any>
   className?: string
-  height?: number
-  icon: Icon
+  icon?: Icon
   size?: number | Size
   verticalAlign?: 'middle' | 'text-bottom' | 'text-top' | 'top' | 'unset'
-  width?: number
 }
 
-declare const Octicon: React.SFC<OcticonProps>
-export default Octicon
+declare const Octicon: React.FC<OcticonProps>
 
-export function createIcon<C extends React.SFC<{}>, W extends number, H extends number>(
-  component: C,
-  size: [W, H]
-): Icon<W, H>
+export default Octicon
 
 export * from './__generated__/icons'

--- a/lib/octicons_react/src/index.js
+++ b/lib/octicons_react/src/index.js
@@ -1,75 +1,7 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
-const sizeMap = {
-  small: 16,
-  medium: 32,
-  large: 64
-}
-
-const alignMap = {
-  top: 'text-top',
-  middle: 'middle'
-}
-
-const defaultSize = [16, 16]
-
-export default function Octicon(props) {
-  const {ariaLabel, children, className, height, icon: Icon, size, verticalAlign, width} = props
-
-  const child = typeof Icon === 'function' ? <Icon /> : React.Children.only(children)
-
-  const widthHeight = child.type.size || defaultSize
-
-  const attrs = {
-    'aria-hidden': ariaLabel ? 'false' : 'true',
-    'aria-label': ariaLabel,
-    className,
-    height,
-    role: 'img',
-    viewBox: [0, 0, ...widthHeight].join(' ')
-  }
-
-  if (width && height) {
-    Object.assign(attrs, {width, height})
-  } else {
-    const dims = {width: widthHeight[0], height: widthHeight[1]}
-    const given = width ? 'width' : 'height'
-    const computed = given === 'width' ? 'height' : 'width'
-    attrs[given] = width || height || sizeMap[size] || size
-    attrs[computed] = attrs[given] * (dims[computed] / dims[given])
-  }
-
-  attrs.style = {
-    display: 'inline-block',
-    fill: 'currentColor',
-    userSelect: 'none',
-    verticalAlign: alignMap[verticalAlign] || verticalAlign
-  }
-
-  return <svg {...attrs}>{child}</svg>
-}
-
-Octicon.defaultProps = {
-  className: 'octicon',
-  size: 16,
-  verticalAlign: 'text-bottom'
-}
-
-Octicon.propTypes = {
-  ariaLabel: PropTypes.string,
-  children: PropTypes.element,
-  height: PropTypes.number,
-  icon: PropTypes.func,
-  size: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(Object.keys(sizeMap))]),
-  verticalAlign: PropTypes.oneOf(['middle', 'text-bottom', 'text-top', 'top', 'unset']),
-  width: PropTypes.number
-}
-
-// Helper since TS makes this painful
-export function createIcon(component, size) {
-  component.size = size
-  return component
+export default function Octicon({icon: Icon, children, ...props}) {
+  return typeof Icon === 'function' ? <Icon {...props} /> : React.cloneElement(React.Children.only(children), props)
 }
 
 export * from './__generated__/icons'

--- a/lib/octicons_react/ts-tests/index.tsx
+++ b/lib/octicons_react/ts-tests/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import Octicon, {getIconByName, iconsByName, MarkGithub, OcticonProps, Plus, Repo} from '../src'
+import Octicon, {getIconByName, iconsByName, MarkGithubIcon, OcticonProps, PlusIcon, RepoIcon} from '../src'
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
@@ -34,18 +34,18 @@ function OcticonsList() {
 function TestOcticons() {
   return (
     <div>
-      <Octicon icon={Repo} size="large" verticalAlign="middle" /> github/github
-      <Octicon icon={Plus} ariaLabel="Add new item" /> New
-      <Octicon icon={MarkGithub} size="large" ariaLabel="GitHub" />
-      <Octicon icon={Repo} className="awesomeClassName" />
+      <Octicon icon={RepoIcon} size="large" verticalAlign="middle" /> github/github
+      <Octicon icon={PlusIcon} ariaLabel="Add new item" /> New
+      <Octicon icon={MarkGithubIcon} size="large" ariaLabel="GitHub" />
+      <Octicon icon={RepoIcon} className="awesomeClassName" />
       <Octicon>
-        <Repo />
+        <RepoIcon />
       </Octicon>
       <Octicon size="large">
-        <Repo />
+        <RepoIcon />
       </Octicon>
-      <Repo />
-      <Repo size="medium" className="test" ariaLabel="repo" verticalAlign="middle" />
+      <RepoIcon />
+      <RepoIcon size="medium" className="test" ariaLabel="repo" verticalAlign="middle" />
     </div>
   )
 }

--- a/lib/octicons_react/ts-tests/index.tsx
+++ b/lib/octicons_react/ts-tests/index.tsx
@@ -31,16 +31,21 @@ function OcticonsList() {
   )
 }
 
-function VerticalAlign() {
+function TestOcticons() {
   return (
-    <h1>
+    <div>
       <Octicon icon={Repo} size="large" verticalAlign="middle" /> github/github
       <Octicon icon={Plus} ariaLabel="Add new item" /> New
       <Octicon icon={MarkGithub} size="large" ariaLabel="GitHub" />
-    </h1>
+      <Octicon icon={Repo} className="awesomeClassName" />
+      <Octicon>
+        <Repo />
+      </Octicon>
+      <Octicon size="large">
+        <Repo />
+      </Octicon>
+      <Repo />
+      <Repo size="medium" className="test" ariaLabel="repo" verticalAlign="middle" />
+    </div>
   )
-}
-
-function WithClassName() {
-  return <Octicon icon={Repo} className="awesomeClassName" />
 }

--- a/lib/octicons_react/ts-tests/index.tsx
+++ b/lib/octicons_react/ts-tests/index.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react'
-import Octicon, {OcticonProps, Beaker, X, Repo, Plus, MarkGithub, getIconByName, iconsByName, createIcon} from '../src'
-
-function Icon({boom}: {boom: boolean}): React.ReactNode {
-  return <Octicon icon={boom ? X : Beaker} />
-}
+import Octicon, {getIconByName, iconsByName, MarkGithub, OcticonProps, Plus, Repo} from '../src'
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
@@ -47,22 +43,4 @@ function VerticalAlign() {
 
 function WithClassName() {
   return <Octicon icon={Repo} className="awesomeClassName" />
-}
-
-const CirclesIcon = createIcon(() => {
-  return (
-    <React.Fragment>
-      <circle r={5} cx={5} cy={5} />
-      <circle r={5} cx={15} cy={5} />
-      <circle r={5} cx={25} cy={5} />
-    </React.Fragment>
-  )
-}, [30, 10])
-
-export function CirclesOcticon(props: Omit<OcticonProps, 'icon'>) {
-  return <Octicon {...props} icon={CirclesIcon} />
-}
-
-function TestCirclesOcticon(): React.ReactElement {
-  return <CirclesOcticon />
 }

--- a/lib/octicons_react/ts-tests/tsconfig.json
+++ b/lib/octicons_react/ts-tests/tsconfig.json
@@ -6,7 +6,7 @@
     "noEmit": true,
     "noImplicitAny": true,
     "jsx": "react",
-    "lib": ["es2015"]
-  },
-  "files": ["../src/index.d.ts", "./index.tsx"]
+    "lib": ["es2015"],
+    "skipLibCheck": true
+  }
 }


### PR DESCRIPTION
## Motivation

As part of the [Octicons refresh](https://github.com/github/design-systems/issues/711) project, we designed a set of 24px icons—as well as 16px icons—to accommodate interfaces that need larger icons. With the addition of this 24px grid size, we no longer have a 1-to-1 mapping of icon name to SVG file. The Octicons React components now need to choose which SVG to render based on the size passed in:

| Before                                                                                                    | After                                                                                                        |
| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
| ![image](https://user-images.githubusercontent.com/4608155/78410106-492bcf80-75c0-11ea-8af3-c7416b3ed2dc.png) | ![image](https://user-images.githubusercontent.com/4608155/78410127-56e15500-75c0-11ea-9ce7-0d9298b1c95b.png) |

This PR implements the "After" diagram. Here's how...

## Implementation

Our current React API for rendering an octicon looks like this:

```jsx
<Octicon icon={Alert} size={24} />
```

The above snippet will render an `<svg>` on the page:

```html
<svg viewBox="..." width="..." height="...">
  <path d="...">
</svg>
```

The `Octicon` component is responsible for rendering the `<svg>` "shell":

```html
<svg viewBox="..." width="..." height="...">

</svg>
```

The `Alert` component is responsible for rendering the elements inside the `<svg>`:

```html
<path d="...">
```

However, since there is no longer a 1-to-1 mapping of icon name to SVG file, `Alert` now needs access to the `size` prop passed to `Octicon` in order to decide whether to render `alert-16.svg` or `alert-24.svg`. And `Octicon` needs to know whether `Alert` chose to render `alert-16.svg` or `alert-24.svg` in order to compute the `viewBox` attribute for the `<svg>` element. 

To avoid creating a complex two-way data flow between `Octicon` and `Alert`, I've pushed all the rendering logic into the `Alert` component. `Alert`—and all the icon components—are now responsible for rendering the entire `<svg>`. `Octicon` just passes props to its icon component without rendering any additional elements, like so:

```jsx
function Octicon({icon: Icon, size}) => {
  return <Icon size={size} />
}
```

## Release notes

* Icon components (e.g. `AlertIcon`, `ArrowRightIcon`, etc.) now accept `size`, `ariaLabel`, `verticalAlign`, and `className` props and can be used on their own. No need to pass them to the `Octicon` component.
  ```jsx
  // Both ways work now:
  <Octicon icon={AlertIcon} size={24} />
  <AlertIcon size={24} />
  ```

* Icon components will now choose the best SVG icon to render based on the `size` passed in.

### BREAKING CHANGES 💥

* All icon component names now include `Icon` at the end (e.g. `Alert` → `AlertIcon`).

* `Octicon` no longer accepts `width` or `height` props. Use the `size` prop instead. In cases where the width and height of an icon are not equal (e.g. logos), the height will be set to the value of the `size` prop and the `width` will be scaled proportionally.

* Setting `verticalAlign="top"` on the `Octicon` component or any icon component will now apply a `vertical-align: top;` style to the `<svg>`. Previously, we were translating "top" to "text-top." So setting `verticalAlign="top"` would apply a `vertical-align: text-top;` style to the `<svg>`. I'm not sure why we did that. If you want a vertical alignment of "text-top," set the `verticalAlign` prop to `"text-top"`.

* Custom icon components passed to the `Octicon` component now need to render the entire `<svg>`, not just the `<path>`.

```diff
function CirclesIcon() {
  return (
-   <React.Fragment>
+   <svg viewBox="0 0 30 10" width="30" height="10">
      <circle r={5} cx={5} cy={5}/>
      <circle r={5} cx={15} cy={5}/>
      <circle r={5} cx={25} cy={5}/>
-   </React.Fragment>
+   </svg>
  )
}

- CirclesIcon.size = [30, 10]
```

## Next steps

The `Octicon` component now seems unnecessary and makes the API bloated.  Should we deprecate it?

If we deprecate the `Octicon` component, we would need to provide an alternative to the `StyledOcticon` component, which exposes system props for styling octicons. We could create a separate package called, say, `@primer/octicons-react-styled` that wraps every icon component with styled-systems props:

```jsx
import {Alert} from '@primer/octicons-react-styled'

<Alert color="gray.5" mr={2} />
```

I'd love to hear other people's thoughts on this 💭 

Closes https://github.com/primer/octicons/issues/393

---

Thank you to @dmarcey for early feedback on this implementation 🙏 