### PR TITLE
[React] Rename "ariaLabel" prop to "aria-label"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@
 
 - `Octicon` no longer accepts `width` or `height` props. Use the `size` prop instead. In cases where the width and height of an icon are not equal (e.g. logos), the height will be set to the value of the `size` prop and the `width` will be scaled proportionally.
 
+- We renamed the `ariaLabel` prop to `aria-label` to be consistent with React: https://reactjs.org/docs/accessibility.html#wai-aria
+
+  ```diff
+  - <AlertIcon ariaLabel="alert">
+  + <AlertIcon aria-label="alert">
+  ```
+
 - Setting `verticalAlign="top"` on the `Octicon` component or any icon component will now apply a `vertical-align: top;` style to the `<svg>`. Previously, we were translating "top" to "text-top." So setting `verticalAlign="top"` would apply a `vertical-align: text-top;` style to the `<svg>`. If you want a vertical alignment of "text-top," set the `verticalAlign` prop to `"text-top"`.
 
 - Custom icon components passed to the `Octicon` component now need to render the entire `<svg>`, not just the `<path>`.

--- a/docs/content/packages/react.mdx
+++ b/docs/content/packages/react.mdx
@@ -113,10 +113,9 @@ export default () => (
 ```
 
 
-### `ariaLabel`
+### `aria-label`
 You have the option of adding accessibility information to the icon with the
-[`aria-label` attribute][aria-label] via the `ariaLabel` prop (note the
-capitalization of `L`!).
+[`aria-label` attribute][aria-label] via the `aria-label` prop.
 
 ```js
 // Example usage
@@ -124,7 +123,7 @@ import Octicon, {Plus} from '@primer/octicons-react'
 
 export default () => (
   <button>
-    <Octicon icon={Plus} ariaLabel="Add new item" /> New
+    <Octicon icon={Plus} aria-label="Add new item" /> New
   </button>
 )
 ```
@@ -147,7 +146,7 @@ import Octicon, {LogoGithub} from '@primer/octicons-react'
 export default () => (
   <h1>
     <a href='https://github.com'>
-      <Octicon icon={LogoGithub} size='large' ariaLabel='GitHub'/>
+      <Octicon icon={LogoGithub} size='large' aria-label='GitHub'/>
     </a>
   </h1>
 )

--- a/lib/octicons_react/script/build.js
+++ b/lib/octicons_react/script/build.js
@@ -72,7 +72,7 @@ import * as React from 'react'
 type Size = 'small' | 'medium' | 'large'
 
 interface IconProps {
-  ariaLabel?: string
+  'aria-label'?: string
   className?: string
   size?: number | Size
   verticalAlign?: 'middle' | 'text-bottom' | 'text-top' | 'top' | 'unset'

--- a/lib/octicons_react/src/__tests__/octicon.js
+++ b/lib/octicons_react/src/__tests__/octicon.js
@@ -13,8 +13,9 @@ describe('Octicon component', () => {
 
   it('passes props to icon prop', () => {
     const {container} = render(
-      <Octicon ariaLabel="icon" className="foo" size={20} verticalAlign="middle" icon={AlertIcon} />
+      <Octicon aria-label="icon" className="foo" size={20} verticalAlign="middle" icon={AlertIcon} />
     )
+    expect(container.querySelector('svg')).toHaveAttribute('aria-label', 'icon')
     expect(container.querySelector('svg')).toHaveAttribute('class', 'foo')
     expect(container.querySelector('svg')).toHaveAttribute('width', '20')
     expect(container.querySelector('svg')).toHaveAttribute('height', '20')
@@ -23,7 +24,7 @@ describe('Octicon component', () => {
 
   it('passes props to icon as child', () => {
     const {container} = render(
-      <Octicon ariaLabel="icon" className="foo" size={20} verticalAlign="middle">
+      <Octicon aria-label="icon" className="foo" size={20} verticalAlign="middle">
         <AlertIcon />
       </Octicon>
     )
@@ -42,7 +43,7 @@ describe('An icon component', () => {
   })
 
   it('sets aria-hidden="false" if ariaLabel prop is present', () => {
-    const {container} = render(<AlertIcon ariaLabel="icon" />)
+    const {container} = render(<AlertIcon aria-label="icon" />)
     expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'false')
     expect(container.querySelector('svg')).toHaveAttribute('aria-label', 'icon')
   })

--- a/lib/octicons_react/src/get-svg-props.js
+++ b/lib/octicons_react/src/get-svg-props.js
@@ -4,7 +4,7 @@ const sizeMap = {
   large: 64
 }
 
-export default function getSvgProps({ariaLabel, className, size, verticalAlign, svgDataByHeight}) {
+export default function getSvgProps({'aria-label': ariaLabel, className, size, verticalAlign, svgDataByHeight}) {
   const height = sizeMap[size] || size
   const naturalHeight = closestNaturalHeight(Object.keys(svgDataByHeight), height)
   const naturalWidth = svgDataByHeight[naturalHeight].width

--- a/lib/octicons_react/src/index.d.ts
+++ b/lib/octicons_react/src/index.d.ts
@@ -5,7 +5,7 @@ import {Icon} from './__generated__/icons'
 type Size = 'small' | 'medium' | 'large'
 
 export interface OcticonProps {
-  ariaLabel?: string
+  'aria-label'?: string
   children?: React.ReactElement<any>
   className?: string
   icon?: Icon

--- a/lib/octicons_react/ts-tests/index.tsx
+++ b/lib/octicons_react/ts-tests/index.tsx
@@ -45,7 +45,7 @@ function TestOcticons() {
         <RepoIcon />
       </Octicon>
       <RepoIcon />
-      <RepoIcon size="medium" className="test" ariaLabel="repo" verticalAlign="middle" />
+      <RepoIcon size="medium" className="test" aria-label="repo" verticalAlign="middle" />
     </div>
   )
 }

--- a/lib/octicons_react/ts-tests/index.tsx
+++ b/lib/octicons_react/ts-tests/index.tsx
@@ -35,8 +35,8 @@ function TestOcticons() {
   return (
     <div>
       <Octicon icon={RepoIcon} size="large" verticalAlign="middle" /> github/github
-      <Octicon icon={PlusIcon} ariaLabel="Add new item" /> New
-      <Octicon icon={MarkGithubIcon} size="large" ariaLabel="GitHub" />
+      <Octicon icon={PlusIcon} aria-label="Add new item" /> New
+      <Octicon icon={MarkGithubIcon} size="large" aria-label="GitHub" />
       <Octicon icon={RepoIcon} className="awesomeClassName" />
       <Octicon>
         <RepoIcon />


### PR DESCRIPTION
This PR renames the `ariaLabel` prop on Octicon React components to `aria-label` to be consistent with React ARIA conventions:  https://reactjs.org/docs/accessibility.html#wai-aria