### PR TITLE
[React] Deprecate Octicon component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,19 @@
 - Icon components (e.g. `AlertIcon`, `ArrowRightIcon`, etc.) now accept `size`, `ariaLabel`, `verticalAlign`, and `className` props and can be used on their own. No need to pass them to the `Octicon` component.
 
   ```jsx
-  // Both ways work now:
-  <Octicon icon={AlertIcon} size={24} />
   <AlertIcon size={24} />
   ```
 
 - Icon components will now choose the best SVG icon to render based on the `size` passed in.
 
 ### BREAKING CHANGES 💥
+
+- The `Octicon` component is deprecated. Use icon components on their own instead:
+
+  ```diff
+  - <Octicon icon={AlertIcon} />
+  + <AlertIcon />
+  ```
 
 - All icon component names now include `Icon` at the end (e.g. `Alert` → `AlertIcon`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,14 @@
 
 - Icon components will now choose the best SVG icon to render based on the `size` passed in.
 
-### BREAKING CHANGES 💥
-
 - The `Octicon` component is deprecated. Use icon components on their own instead:
 
   ```diff
   - <Octicon icon={AlertIcon} />
   + <AlertIcon />
   ```
+
+### BREAKING CHANGES 💥
 
 - All icon component names now include `Icon` at the end (e.g. `Alert` → `AlertIcon`).
 

--- a/docs/content/packages/react.mdx
+++ b/docs/content/packages/react.mdx
@@ -106,11 +106,7 @@ import {PlusIcon} from '@primer/octicons-react'
 
 export default () => (
   <button>
-<<<<<<< HEAD
-    <PlusIcon ariaLabel="Add new item" /> New
-=======
-    <Octicon icon={Plus} aria-label="Add new item" /> New
->>>>>>> origin/v2
+    <PlusIcon aria-label="Add new item" /> New
   </button>
 )
 ```

--- a/docs/content/packages/react.mdx
+++ b/docs/content/packages/react.mdx
@@ -14,39 +14,18 @@ npm install @primer/octicons-react
 
 ## Usage
 
-### `<Octicon>`
-The `<Octicon>` component is really just the "shell" of an Octicon that renders
-the `<svg>` element and all of its attributes. To render a specific icon, you
-must pass it either via the `icon` prop, or as the only child:
-
-```jsx
-/**
- * The prop form is shorter, but doesn't allow you to pass icon props.
- */
-<Octicon icon={Icon} />
-
-/**
- * The child form allows you to pass props.
- */
-<Octicon><Icon x={10}/></Octicon>
-```
-
-Note that none of our builtin icons take props, so unless you're creating
-[custom icons](#custom-icons) you'll probably want to use the `icon` prop form.
-
 ### Icons
-The `@primer/octicons-react` module exports the `Octicon` component as
-`default` and the individual icon symbols as separate [named
+The `@primer/octicons-react` module exports individual icons as [named
 exports](https://ponyfoo.com/articles/es6-modules-in-depth#named-exports). This
 allows you to import only the icons that you need without blowing up your
 bundle:
 
 ```jsx
 import React from 'react'
-import Octicon, {Beaker, Zap} from '@primer/octicons-react'
+import {BeakerIcon, ZapIcon} from '@primer/octicons-react'
 
 export default function Icon({boom}) {
-  return <Octicon icon={boom ? Zap : Beaker}/>
+  return boom ? <ZapIcon /> : <BeakerIcon />
 }
 ```
 
@@ -61,16 +40,17 @@ named exports:
 
 #### `getIconByName()`
 The `getIconByName` export is a function that takes a lowercase octicon name
-(such as `arrow-right`) and returns the corresponding icon class. Using this
-helper, it's possible to create an Octicon class that takes a `name` prop and
-resolves it to the right component:
+(such as `arrow-right`) and returns the corresponding icon component. Using this
+helper, it's possible to create an component that takes a `name` prop and
+resolves it to the right icon:
 
 ```jsx
 import React from 'react'
-import Octicon, {getIconByName} from '@primer/octicons-react'
+import {getIconByName} from '@primer/octicons-react'
 
 export default function OcticonByName({name, ...props}) {
-  return <Octicon {...props} icon={getIconByName(name)} />
+  const Icon = getIconByName(name)
+  return <Icon {...props} />
 }
 ```
 
@@ -81,17 +61,20 @@ the octicons:
 
 ```jsx
 import React from 'react'
-import Octicon, {iconsByName} from '@primer/octicons-react'
+import {iconsByName} from '@primer/octicons-react'
 
 export default function OcticonsList() {
   return (
     <ul>
-      {Object.keys(iconsByName).map(key => (
-        <li key={key}>
-          <tt>{key}</tt>
-          <Octicon icon={iconsByName[key]}/>
-        </li>
-      ))}
+      {Object.keys(iconsByName).map(key => {
+        const Icon = iconsByName[key]
+        return (
+          <li key={key}>
+            <tt>{key}</tt>
+            <Icon />
+          </li>
+        )
+      })}
     </ul>
   )
 }
@@ -103,11 +86,11 @@ styles. You can change the alignment via the `verticalAlign` prop, which can be
 either `middle`, `text-bottom`, `text-top`, or `top`.
 
 ```js
-import Octicon, {Repo} from '@primer/octicons-react'
+import {RepoIcon} from '@primer/octicons-react'
 
 export default () => (
   <h1>
-    <Octicon icon={Repo} size='large' verticalAlign='middle' /> github/github
+    <RepoIcon verticalAlign='middle' /> github/github
   </h1>
 )
 ```
@@ -120,11 +103,11 @@ capitalization of `L`!).
 
 ```js
 // Example usage
-import Octicon, {Plus} from '@primer/octicons-react'
+import {PlusIcon} from '@primer/octicons-react'
 
 export default () => (
   <button>
-    <Octicon icon={Plus} ariaLabel="Add new item" /> New
+    <PlusIcon ariaLabel="Add new item" /> New
   </button>
 )
 ```
@@ -142,44 +125,31 @@ render octicons at standard sizes:
 
 ```js
 // Example usage
-import Octicon, {LogoGithub} from '@primer/octicons-react'
+import {LogoGithubIcon} from '@primer/octicons-react'
 
 export default () => (
   <h1>
     <a href='https://github.com'>
-      <Octicon icon={LogoGithub} size='large' ariaLabel='GitHub'/>
+      <LogoGithubIcon size='large' ariaLabel='GitHub'/>
     </a>
   </h1>
 )
 ```
 
+### `Octicon` (DEPRECATED)
 
-## Custom icons
-Each of our icon components is really just a function that renders its SVG
-`<path>`. To accommodate icons varying aspect ratios, the `Octicon` component
-determines the `viewBox` of the `<svg>` element by first looking for a `size`
-array on the icon component class. For instance, if you wanted to create a
-custom icon that consisted of three circles side by side, you could do this:
+> ⚠️ The `Octicon` component is deprecated. Use icon components on their own instead:
+> ```diff
+- <Octicon icon={AlertIcon} />
++ <AlertIcon />
+```
+
+The `Octicon` component is wrapper that passes props to its icon component. To render a specific icon, you
+can pass it either via the `icon` prop, or as the only child:
 
 ```jsx
-import React from 'react'
-import Octicon from '@primer/octicons-react'
-
-function CirclesIcon() {
-  return (
-    <React.Fragment>
-      <circle r={5} cx={5} cy={5}/>
-      <circle r={5} cx={15} cy={5}/>
-      <circle r={5} cx={25} cy={5}/>
-    </React.Fragment>
-  )
-}
-
-CirclesIcon.size = [30, 10]
-
-export default CirclesOcticon(props) {
-  return <Octicon {...props} icon={CirclesIcon} />
-}
+<Octicon icon={Icon} />
+<Octicon><Icon x={10}/></Octicon>
 ```
 
 [octicons]: https://octicons.github.com/

--- a/lib/octicons_react/src/index.d.ts
+++ b/lib/octicons_react/src/index.d.ts
@@ -13,6 +13,9 @@ export interface OcticonProps {
   verticalAlign?: 'middle' | 'text-bottom' | 'text-top' | 'top' | 'unset'
 }
 
+/**
+ * @deprecated Use icon components on their own instead (e.g. `<Octicon icon={AlertIcon} />` → `<AlertIcon />`)
+ */
 declare const Octicon: React.FC<OcticonProps>
 
 export default Octicon

--- a/lib/octicons_react/src/index.js
+++ b/lib/octicons_react/src/index.js
@@ -1,6 +1,11 @@
 import React from 'react'
 
 export default function Octicon({icon: Icon, children, ...props}) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    // eslint-disable-next-line github/unescaped-html-literal
+    '<Octicon> is deprecated. Use icon components on their own instead (e.g. <Octicon icon={AlertIcon} /> → <AlertIcon />)'
+  )
   return typeof Icon === 'function' ? <Icon {...props} /> : React.cloneElement(React.Children.only(children), props)
 }
 


### PR DESCRIPTION
As of https://github.com/primer/octicons/pull/395, `Octicon` just passes props to its icon component without rendering any additional elements. `Octicon` now seems unnecessary and makes the API bloated. This PR deprecates `Octicon` by adding a `console.warn` call in the component definition and updating the docs.

### Release notes

The `Octicon` component is deprecated. Use icon components on their own instead:

  ```diff
  - <Octicon icon={AlertIcon} />
  + <AlertIcon />
  ```