### PR TITLE
Add a link to the new Octicons website

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -4,7 +4,15 @@ title: Octicons
 
 import {HeroLayout} from '@primer/gatsby-theme-doctocat'
 import Icons from '../src/components/icons'
+import {Flash, Button, Flex} from '@primer/components'
 
 export default HeroLayout
+
+<Flash mb={4}>
+  <Flex flexDirection={['column', 'row']} alignItems={["flex-start", "center"]} justifyContent="space-between">
+    <Text>We're working on a new look for Octicons</Text>
+    <Button as="a" href="https://octicons-git-v2.primer.now.sh" mt={[3, 0]}>Check it out</Button>
+  </Flex>
+</Flash>
 
 <Icons />


### PR DESCRIPTION
### Problem

The new Octicons website is hard to find.

### Solution

This PR adds a banner on the old Octicons website that links to the new Octicons website:

![image](https://user-images.githubusercontent.com/4608155/79783586-ba27f280-82f5-11ea-8bcf-65413a5f411e.png)

I'm not attached to the wording. If you can think of better copy, I'm happy to update the banner 😸  


