### PR TITLE
[Docs] Show version number in hero

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/components/hero.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/hero.js
@@ -11,7 +11,7 @@ function Hero() {
           Octicons
         </Heading>
         <Text as="p" mt={0} mb={3} color="blue.2" fontSize={4}>
-          You project. GitHub's icons.
+          Your project. GitHub's icons.
         </Text>
         <Text as="p" m={0} color="blue.3" fontFamily="mono">
           v{version}

--- a/docs/src/@primer/gatsby-theme-doctocat/components/hero.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/hero.js
@@ -1,0 +1,24 @@
+import {Box, Heading, Text} from '@primer/components'
+import {Container} from '@primer/gatsby-theme-doctocat'
+import React from 'react'
+import {version} from '../../../../../package.json'
+
+function Hero() {
+  return (
+    <Box bg="black" py={6}>
+      <Container>
+        <Heading color="blue.4" fontSize={7} m={0}>
+          Octicons
+        </Heading>
+        <Text as="p" mt={0} mb={3} color="blue.2" fontSize={4}>
+          You project. GitHub's icons.
+        </Text>
+        <Text as="p" m={0} color="blue.3" fontFamily="mono">
+          v{version}
+        </Text>
+      </Container>
+    </Box>
+  )
+}
+
+export default Hero


### PR DESCRIPTION
This PR adds the current octicons version number (found in `package.json`) to the site hero so people know what version of octicons they're looking at.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4608155/80030997-ea11fa00-849d-11ea-8273-f6f0aac31f2a.png)  | ![image](https://user-images.githubusercontent.com/4608155/80031160-29d8e180-849e-11ea-84b1-63b5d55a7e7a.png) |