### PR TITLE
Update docs to clarify temporary v2 packages

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -4,8 +4,13 @@ title: Octicons
 
 import {HeroLayout} from '@primer/gatsby-theme-doctocat'
 import Icons from '../src/components/icons'
-import {Flash, Button, Flex} from '@primer/components'
+import {Flash, Button, Flex, Link} from '@primer/components'
+import {Link as GatsbyLink} from 'gatsby'
 
 export default HeroLayout
+
+<Flash scheme="yellow" mb={4}>
+Octicons v10.0.0 is not released yet. In the meantime, we've created temporary <Link as={GatsbyLink} to="/packages">packages</Link> so you can preview the new icons. If you're looking for the latest stable release of Octicons, go <Link href="https://primer.style/octicons">here</Link>.
+</Flash>
 
 <Icons />

--- a/docs/content/packages/javascript.mdx
+++ b/docs/content/packages/javascript.mdx
@@ -1,27 +1,33 @@
 ---
 title: JavaScript
-status: Stable
-source: 'https://github.com/primer/octicons/tree/master/lib/octicons_node'
+status: Experimental 
+source: 'https://github.com/primer/octicons/tree/v2/lib/octicons_node'
 ---
 
-[![npm version](https://img.shields.io/npm/v/@primer/octicons.svg)](https://www.npmjs.org/package/@primer/octicons)
+import {Flash, Link} from '@primer/components'
+
+[![npm version](https://img.shields.io/npm/v/@primer/octicons-v2/canary.svg)](https://www.npmjs.org/package/@primer/octicons-v2)
+
+<Flash scheme="yellow">
+This is a temporary package containing icons that will be released in Octicons v10.0.0. If you're looking for the latest stable release of Octicons, go <Link href="https://primer.style/octicons/packages/ruby">here</Link>.
+</Flash> 
 
 ## Install
 
-This package is distributed with [npm][npm]. After [installing npm][install-npm], you can install `@primer/octicons` with this command:
+This package is distributed with [npm][npm]. After [installing npm][install-npm], you can install `@primer/octicons-v2` with this command:
 
 ```shell
-npm install @primer/octicons
+npm install @primer/octicons-v2@canary
 ```
 
 ## Usage
 
-For all the usages, we recommend using the CSS located in [`build/build.css`](https://unpkg.com/@primer/octicons/build/build.css). This is some simple CSS to normalize the icons and inherit colors.
+For all the usages, we recommend using the CSS located in [`build/build.css`](https://unpkg.com/@primer/octicons-v2@canary/build/build.css). This is some simple CSS to normalize the icons and inherit colors.
 
-After installing `@primer/octicons` you can access the icons like this:
+After installing `@primer/octicons-v2` you can access the icons like this:
 
 ```js
-var octicons = require("@primer/octicons")
+var octicons = require("@primer/octicons-v2")
 octicons.alert
 // { keywords: [ 'warning', 'triangle', 'exclamation', 'point' ],
 //   path: '<path d="M8.865 1.52c-.18-.31-.51-.5-.87-.5s-.69.19-.87.5L.275 13.5c-.18.31-.18.69 0 1 .19.31.52.5.87.5h13.7c.36 0 .69-.19.86-.5.17-.31.18-.69.01-1L8.865 1.52zM8.995 13h-2v-2h2v2zm0-3h-2V6h2v4z"/>',

--- a/docs/content/packages/jekyll.mdx
+++ b/docs/content/packages/jekyll.mdx
@@ -1,10 +1,16 @@
 ---
 title: Jekyll
-status: Stable
-source: 'https://github.com/primer/octicons/tree/master/lib/octicons_jekyll'
+status: Experimental 
+source: 'https://github.com/primer/octicons/tree/v2/lib/octicons_jekyll'
 ---
 
-[![Gem version](https://img.shields.io/gem/v/jekyll-octicons.svg)](https://rubygems.org/gems/jekyll-octicons)
+import {Flash, Link} from '@primer/components'
+
+[![Gem version](https://img.shields.io/gem/v/jekyll-octicons_v2.svg)](https://rubygems.org/gems/jekyll-octicons_v2)
+
+<Flash scheme="yellow" my={3}>
+This is a temporary package containing icons that will be released in Octicons v10.0.0. If you want to use the latest stable release of Octicons, go <Link href="https://primer.style/octicons/packages/jekyll">here</Link>.
+</Flash> 
 
 This jekyll liquid tag is a plugin that will let you easily include svg octicons in your jekyll sites.
 
@@ -13,14 +19,14 @@ This jekyll liquid tag is a plugin that will let you easily include svg octicons
 1. Add this to your `Gemfile`
 
     ```rb
-    gem 'jekyll-octicons'
+    gem 'jekyll-octicons_v2'
     ```
 
 2. Add this to your jekyll `_config.yml`
 
     ```yml
     gems:
-      - jekyll-octicons
+      - jekyll-octicons_v2
     ```
 
 3. Use this tag in your jekyll templates
@@ -29,4 +35,4 @@ This jekyll liquid tag is a plugin that will let you easily include svg octicons
     {% octicon alert height:32 class:"right left" aria-label:hi %}
     ```
 
-We recommend including the CSS in the [`@primer/octicons`](/packages/javascript) npm module. You can also npm install that package and include `build/build.css` in your styles.
+We recommend including the CSS in the [`@primer/octicons-v2`](/packages/javascript) npm module. You can also npm install that package and include `build/build.css` in your styles.

--- a/docs/content/packages/rails.mdx
+++ b/docs/content/packages/rails.mdx
@@ -1,11 +1,16 @@
 ---
 title: Rails
-status: Stable
-source: 'https://github.com/primer/octicons/tree/master/lib/octicons_helper'
+status: Experimental
+source: 'https://github.com/primer/octicons/tree/v2/lib/octicons_v2_helper'
 ---
 
-[![Gem version](https://img.shields.io/gem/v/octicons_helper.svg)](https://rubygems.org/gems/octicons_helper)
+import {Flash, Link} from '@primer/components'
 
+[![Gem version](https://img.shields.io/gem/v/octicons_v2_helper.svg)](https://rubygems.org/gems/octicons_v2_helper)
+
+<Flash scheme="yellow" my={3}>
+This is a temporary package containing icons that will be released in Octicons v10.0.0. If you want to use the latest stable release of Octicons, go <Link href="https://primer.style/octicons/packages/rails">here</Link>.
+</Flash>
 
 This rails helper lets you easily include svg octicons in your rails apps.
 
@@ -14,13 +19,13 @@ This rails helper lets you easily include svg octicons in your rails apps.
 1. Add this to your `Gemfile`
 
     ```rb
-    gem 'octicons_helper'
+    gem 'octicons_v2_helper'
     ```
 
 3. Use this tag in your erbs
 
     ```rb
-    <%= octicon "alert", :height => 32,  :class => "right left", :"aria-label" => "hi" %>
+    <%= octicon_v2 "alert", :height => 32,  :class => "right left", :"aria-label" => "hi" %>
     ```
 
-We recommend including the CSS in the [`@primer/octicons`](/packages/javascript) npm module. You can also npm install that package and include `build/build.css` in your styles.
+We recommend including the CSS in the [`@primer/octicons-v2`](/packages/javascript) npm module. You can also npm install that package and include `build/build.css` in your styles.

--- a/docs/content/packages/react.mdx
+++ b/docs/content/packages/react.mdx
@@ -1,28 +1,34 @@
 ---
 title: React
-status: Stable
-source: 'https://github.com/primer/octicons/tree/master/lib/octicons_react'
+status: Experimental 
+source: 'https://github.com/primer/octicons/tree/v2/lib/octicons_react'
 ---
 
-[![npm version](https://img.shields.io/npm/v/@primer/octicons-react.svg)](https://www.npmjs.org/package/@primer/octicons-react)
+import {Flash, Link} from '@primer/components'
+
+[![npm version](https://img.shields.io/npm/v/@primer/octicons-v2-react/canary.svg)](https://www.npmjs.org/package/@primer/octicons-v2-react)
+
+<Flash scheme="yellow" my={3}>
+This is a temporary package containing icons that will be released in Octicons v10.0.0. If you want to use the latest stable release of Octicons, go <Link href="https://primer.style/octicons/packages/react">here</Link>.
+</Flash> 
 
 ## Install
 
 ```shell
-npm install @primer/octicons-react
+npm install @primer/octicons-v2-react@canary
 ```
 
 ## Usage
 
 ### Icons
-The `@primer/octicons-react` module exports individual icons as [named
+The `@primer/octicons-v2-react` module exports individual icons as [named
 exports](https://ponyfoo.com/articles/es6-modules-in-depth#named-exports). This
 allows you to import only the icons that you need without blowing up your
 bundle:
 
 ```jsx
 import React from 'react'
-import {BeakerIcon, ZapIcon} from '@primer/octicons-react'
+import {BeakerIcon, ZapIcon} from '@primer/octicons-v2-react'
 
 export default function Icon({boom}) {
   return boom ? <ZapIcon /> : <BeakerIcon />
@@ -46,7 +52,7 @@ resolves it to the right icon:
 
 ```jsx
 import React from 'react'
-import {getIconByName} from '@primer/octicons-react'
+import {getIconByName} from '@primer/octicons-v2-react'
 
 export default function OcticonByName({name, ...props}) {
   const Icon = getIconByName(name)
@@ -61,7 +67,7 @@ the octicons:
 
 ```jsx
 import React from 'react'
-import {iconsByName} from '@primer/octicons-react'
+import {iconsByName} from '@primer/octicons-v2-react'
 
 export default function OcticonsList() {
   return (
@@ -86,7 +92,7 @@ styles. You can change the alignment via the `verticalAlign` prop, which can be
 either `middle`, `text-bottom`, `text-top`, or `top`.
 
 ```js
-import {RepoIcon} from '@primer/octicons-react'
+import {RepoIcon} from '@primer/octicons-v2-react'
 
 export default () => (
   <h1>
@@ -102,7 +108,7 @@ You have the option of adding accessibility information to the icon with the
 
 ```js
 // Example usage
-import {PlusIcon} from '@primer/octicons-react'
+import {PlusIcon} from '@primer/octicons-v2-react'
 
 export default () => (
   <button>
@@ -124,7 +130,7 @@ render octicons at standard sizes:
 
 ```js
 // Example usage
-import {LogoGithubIcon} from '@primer/octicons-react'
+import {LogoGithubIcon} from '@primer/octicons-v2-react'
 
 export default () => (
   <h1>

--- a/docs/content/packages/ruby.mdx
+++ b/docs/content/packages/ruby.mdx
@@ -1,17 +1,23 @@
 ---
 title: Ruby
-status: Stable
-source: 'https://github.com/primer/octicons/tree/master/lib/octicons_gem'
+status: Experimental
+source: 'https://github.com/primer/octicons/tree/v2/lib/octicons_gem'
 ---
 
-[![Gem version](https://img.shields.io/gem/v/octicons.svg)](https://rubygems.org/gems/octicons)
+import {Flash, Link} from '@primer/components'
+
+[![Gem version](https://img.shields.io/gem/v/octicons_v2.svg)](https://rubygems.org/gems/octicons_v2)
+
+<Flash scheme="yellow" my={3}>
+This is a temporary package containing icons that will be released in Octicons v10.0.0. If you want to use the latest stable release of Octicons, go <Link href="https://primer.style/octicons/packages/ruby">here</Link>.
+</Flash> 
 
 ## Install
 
 Add this to your `Gemfile`
 
 ```rb
-gem 'octicons'
+gem 'octicons_v2'
 ```
 
 Then `bundle install`.
@@ -19,15 +25,15 @@ Then `bundle install`.
 ## Usage
 
 ```rb
-require 'octicons'
-icon = Octicons::Octicon.new("x")
+require 'octicons_v2'
+icon = OcticonsV2::OcticonV2.new("x")
 icon.to_svg
 # <svg class="octicon octicon-x" viewBox="0 0 16 16" width="16" height="16" version="1.1" "aria-hidden"="true"><path d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"></path></svg>
 ```
 
 ## Documentation
 
-The `Octicon` class takes two arguments. The first is the symbol of the icon, and the second is a hash of arguments representing html attributes
+The `OcticonV2` class takes two arguments. The first is the symbol of the icon, and the second is a hash of arguments representing html attributes
 
 ### `symbol` _(required)_
 
@@ -49,7 +55,7 @@ Once initialized, you can read a few properties from the icon.
 Returns the string of the symbol name
 
 ```rb
-icon = Octicons::Octicon.new("x")
+icon = OcticonsV2::OcticonV2.new("x")
 icon.symbol
 # "x"
 ```
@@ -59,7 +65,7 @@ icon.symbol
 Path returns the string representation of the path of the icon.
 
 ```rb
-icon = Octicons::Octicon.new("x")
+icon = OcticonsV2::OcticonV2.new("x")
 icon.path
 # <path d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"></path>
 ```
@@ -69,7 +75,7 @@ icon.path
 This is a hash of all the `options` that will be added to the output tag.
 
 ```rb
-icon = Octicons::Octicon.new("x")
+icon = OcticonsV2::OcticonV2.new("x")
 icon.options
 # {:class=>"octicon octicon-x", :viewBox=>"0 0 12 16", :version=>"1.1", :width=>12, :height=>16, :"aria-hidden"=>"true"}
 ```
@@ -87,7 +93,7 @@ Height is the icon's true height. Based on the svg view box height. _Note, this 
 Returns an array of keywords for the icon. The data comes from the [data file in lib](../data.json). Consider contributing more aliases for the icons.
 
 ```rb
-icon = Octicons::Octicon.new("x")
+icon = OcticonsV2::OcticonV2.new("x")
 icon.keywords
 # ["remove", "close", "delete"]
 ```
@@ -99,7 +105,7 @@ icon.keywords
 Returns a string of the svg tag
 
 ```rb
-icon = Octicons::Octicon.new("x")
+icon = OcticonsV2::OcticonV2.new("x")
 icon.to_svg
 # <svg class="octicon octicon-x" viewBox="0 0 16 16" width="16" height="16" version="1.1" "aria-hidden"="true"><path d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"></path></svg>
 ```

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -262,6 +262,11 @@
         "@babel/types": "^7.8.3"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+    },
     "@babel/helper-wrap-function": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
@@ -344,6 +349,15 @@
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
       }
     },
+    "@babel/plugin-proposal-numeric-separator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz",
+      "integrity": "sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz",
@@ -418,6 +432,14 @@
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.8.3.tgz",
+      "integrity": "sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -848,6 +870,18 @@
         "semver": "^5.5.0"
       }
     },
+    "@babel/preset-modules": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
+      "integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      }
+    },
     "@babel/preset-react": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.8.3.tgz",
@@ -1258,39 +1292,154 @@
       }
     },
     "@mdx-js/mdx": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.5.7.tgz",
-      "integrity": "sha512-db1E3P0HCgSUX768Y/jIcr5h41VR5AsvaOmPTydltNM4R8Uh863IqDvnkpa7l829bY/tp6wrMBWM2NH0oLuxHw==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.5.9.tgz",
+      "integrity": "sha512-K/qYIWwV5+V1ChVHga3ZzXlXtEuNsBOt/QI54K+DvD4ayu9WdbBv/953JdC2ZPrHQek48WIbKBH27omZPA6ZPA==",
       "requires": {
-        "@babel/core": "7.8.4",
+        "@babel/core": "7.9.0",
         "@babel/plugin-syntax-jsx": "7.8.3",
         "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-        "@mdx-js/util": "^1.5.7",
-        "babel-plugin-apply-mdx-type-prop": "^1.5.7",
-        "babel-plugin-extract-import-names": "^1.5.7",
+        "@mdx-js/util": "^1.5.9",
+        "babel-plugin-apply-mdx-type-prop": "^1.5.9",
+        "babel-plugin-extract-import-names": "^1.5.9",
         "camelcase-css": "2.0.1",
         "detab": "2.0.3",
-        "hast-util-raw": "5.0.1",
+        "hast-util-raw": "5.0.2",
         "lodash.uniq": "4.5.0",
-        "mdast-util-to-hast": "7.0.0",
-        "remark-mdx": "^1.5.7",
-        "remark-parse": "7.0.2",
-        "remark-squeeze-paragraphs": "3.0.4",
+        "mdast-util-to-hast": "8.2.0",
+        "remark-footnotes": "1.0.0",
+        "remark-mdx": "^1.5.9",
+        "remark-parse": "8.0.1",
+        "remark-squeeze-paragraphs": "4.0.0",
         "style-to-object": "0.3.0",
-        "unified": "8.4.2",
+        "unified": "9.0.0",
         "unist-builder": "2.0.3",
         "unist-util-visit": "2.0.2"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+          "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.0",
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helpers": "^7.9.0",
+            "@babel/parser": "^7.9.0",
+            "@babel/template": "^7.8.6",
+            "@babel/traverse": "^7.9.0",
+            "@babel/types": "^7.9.0",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
+          "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+          "requires": {
+            "@babel/types": "^7.9.5",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+          "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.9.5"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+          "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+          "requires": {
+            "@babel/helper-module-imports": "^7.8.3",
+            "@babel/helper-replace-supers": "^7.8.6",
+            "@babel/helper-simple-access": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/template": "^7.8.6",
+            "@babel/types": "^7.9.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+          "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+          "requires": {
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.9.0",
+            "@babel/types": "^7.9.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.9.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+          "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+        },
+        "@babel/traverse": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+          "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.5",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.9.0",
+            "@babel/types": "^7.9.5",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+          "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        }
       }
     },
     "@mdx-js/react": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.5.7.tgz",
-      "integrity": "sha512-OxX/GKyVlqY7WqyRcsIA/qr7i1Xq3kAVNUhSSnL1mfKKNKO+hwMWcZX4WS2OItLtoavA2/8TVDHpV/MWKWyfvw=="
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.5.9.tgz",
+      "integrity": "sha512-rengdUSedIdIQbXPSeafItCacTYocARAjUA51b6R1KNHmz+59efz7UmyTKr73viJQZ98ouu7iRGmOTtjRrbbWA=="
     },
     "@mdx-js/util": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.5.7.tgz",
-      "integrity": "sha512-SV+V8A+Y33pmVT/LWk/2y51ixIyA/QH1XL+nrWAhoqre1rFtxOEZ4jr0W+bKZpeahOvkn/BQTheK+dRty9o/ig=="
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.5.9.tgz",
+      "integrity": "sha512-hty9ftw/RENS+6pEXTy4vi46CO7cDRdhcELxCaklcGTuxeqi9OROJ+oi03RJd2O2V+3wY5geGAdXKlPQCOTE/Q=="
     },
     "@mikaelkristiansson/domready": {
       "version": "1.0.10",
@@ -1412,9 +1561,9 @@
       }
     },
     "@primer/gatsby-theme-doctocat": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.18.0.tgz",
-      "integrity": "sha512-BwTye2qcQFdf2cuStPJe1ztAxHKrEB5z4jfPygppq+0lV9uQVpNJcmzh0/Bp4A6+SrhUoHNUW2N2vwe6nqnn1g==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.20.1.tgz",
+      "integrity": "sha512-VwqpZmQlS5zAMGOXwXAngs8wRAGO+XbpQ269zr7br8ZIIaHYIOCJuAOkCpQQbNvtgfyPA9tl0gjsjKFkEJEEpw==",
       "requires": {
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",
@@ -1766,9 +1915,9 @@
       }
     },
     "@types/babel__core": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
-      "integrity": "sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
+      "integrity": "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==",
       "requires": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0",
@@ -1795,9 +1944,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.9.tgz",
-      "integrity": "sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==",
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.10.tgz",
+      "integrity": "sha512-74fNdUGrWsgIB/V9kTO5FGHPWYY6Eqn+3Z7L6Hc4e/BxjYV7puvBqp5HwsVYYfLm6iURYBNCx4Ut37OF9yitCw==",
       "requires": {
         "@babel/types": "^7.3.0"
       }
@@ -3553,12 +3702,12 @@
       }
     },
     "babel-plugin-apply-mdx-type-prop": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.5.7.tgz",
-      "integrity": "sha512-SUDwTmMmxzaAZ1YfAPnL2UI3q/JEs+fekx/QTZYEgK+cVGMwS/PrCeK9UDlTHOYJr9b4mieR+iLhm43jrav2WA==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.5.9.tgz",
+      "integrity": "sha512-3uNQ4Zo/TjOaB0E98m6ez2Xfrb7IYAs5BB4b8zQXggPCCppg5kjQEe8AglH6F6b94+q7Qv/cNTnoNqGXs6RBEA==",
       "requires": {
         "@babel/helper-plugin-utils": "7.8.3",
-        "@mdx-js/util": "^1.5.7"
+        "@mdx-js/util": "^1.5.9"
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -3570,9 +3719,9 @@
       }
     },
     "babel-plugin-extract-import-names": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.5.7.tgz",
-      "integrity": "sha512-kZX4g9ehTyxjdbq2rb8wW307+jNu5z3KllYs8cnbapSwclT9wBErJoqvKKZAkuiaufp0r+7WaIvjhKtJ7QlG3A==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.5.9.tgz",
+      "integrity": "sha512-0V3/VJClG/pUn7wnlmWByJdhJklZWD4XvR9P+Q7wDWs9kS48lmmB5Pp6+zvbTBBQGlqJB5/bBtwMRm4zdoPNzg==",
       "requires": {
         "@babel/helper-plugin-utils": "7.8.3"
       }
@@ -3921,9 +4070,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -5572,9 +5721,9 @@
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
     },
     "css-selector-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.3.0.tgz",
-      "integrity": "sha1-XxrUPi2O77/cME/NOaUhZklD4+s="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
+      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g=="
     },
     "css-selector-tokenizer": {
       "version": "0.7.1",
@@ -5822,9 +5971,9 @@
       "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
     },
     "date-fns": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.11.0.tgz",
-      "integrity": "sha512-8P1cDi8ebZyDxUyUprBXwidoEtiQAawYPGvpfb+Dg0G6JrQ+VozwOmm91xYC0vAv1+0VmLehEPb+isg4BGUFfA=="
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.12.0.tgz",
+      "integrity": "sha512-qJgn99xxKnFgB1qL4jpxU7Q2t0LOn1p8KMIveef3UZD7kqjT3tpFNNdXJelEHhE+rUgffriXriw/sOSU+cS1Hw=="
     },
     "debug": {
       "version": "4.1.1",
@@ -8097,9 +8246,9 @@
       }
     },
     "framer-motion": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-1.10.0.tgz",
-      "integrity": "sha512-w96DBIg2hBQ6JFOUhrVddtxaHLYicR9aUqvA8IsrGrHnumK82nwO9+5amiFiI6RKhS0ViJzh3Jx+y6Hy5TgJqQ==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-1.10.3.tgz",
+      "integrity": "sha512-VooCzGWg7brSO4Gc0YwpY5AadJe4OPS74ZyOlOHWll5rMXCoOc6Ia3uDQ6RfOJlwCP/D9TQuRGtboyJiVXjVcw==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
         "@popmotion/easing": "^1.0.2",
@@ -8752,18 +8901,18 @@
       }
     },
     "gatsby-plugin-catch-links": {
-      "version": "2.1.28",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.1.28.tgz",
-      "integrity": "sha512-3cemo2r4Q1JcJEVqOfWhXcrNXgocoaDSEV1c2gogGemZcWIHLbq2dh0zRABu/QKZ4p6nb8uTgh8DHFugZ1zbdg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.2.3.tgz",
+      "integrity": "sha512-EHacyfSRF6wgxxJhpNgr1P+0IAEZ/GghWu3rw7XsLEfXJGYqHAJEOR8+lDsMP9TxMMjGRfomYO+3cwqswxMkiQ==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "escape-string-regexp": "^1.0.5"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -8776,20 +8925,20 @@
       }
     },
     "gatsby-plugin-manifest": {
-      "version": "2.2.48",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.48.tgz",
-      "integrity": "sha512-RWD2HlKT7TFcXs3SIiZTWjq3Ud4z79cms8pBLXjlNNddatnSNi0ne2RknERCQgmTQvcJ9eNeIzfzVtR3WAcBYA==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.3.6.tgz",
+      "integrity": "sha512-B5z4z+akH9negZGUIoo7UUiHLL4BmQZ/2mI9g4GmoW/Zw5OA4QZOxF0kdy/vluVqxphJ6RdQDx0kIf1qCtBeZQ==",
       "requires": {
         "@babel/runtime": "^7.8.7",
-        "gatsby-core-utils": "^1.0.34",
+        "gatsby-core-utils": "^1.1.3",
         "semver": "^5.7.1",
-        "sharp": "^0.23.4"
+        "sharp": "^0.25.1"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -8821,9 +8970,9 @@
           }
         },
         "gatsby-core-utils": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.34.tgz",
-          "integrity": "sha512-CVuUQTVY+0X7vAqFnDeRT0ZkN0tUXvk6GLvUqfmoOzBvX9HphiR0VTi1tEYrsc5DSaz7Oyhr0vdp8j/e96rH1w==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.1.3.tgz",
+          "integrity": "sha512-PntSiNCFo1/ZKjp00qgLBj2jdwY7M+maV21RXb1k7Ud9Vv9j0dGQsaVb9YXFTqXAf8bG0Xyqsqq4mPU1iNYLDw==",
           "requires": {
             "ci-info": "2.0.0",
             "configstore": "^5.0.1",
@@ -8836,9 +8985,9 @@
           "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         },
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "requires": {
             "semver": "^6.0.0"
           },
@@ -8882,9 +9031,9 @@
       }
     },
     "gatsby-plugin-mdx": {
-      "version": "1.0.84",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.0.84.tgz",
-      "integrity": "sha512-OfMzdSybwB6cFGiTPbW2SDbv37V7NOk3/OAhn27fixOLPGqJ//ontIRldZLQZKZfEa30U2gnnh9XTG3C5jvfVQ==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.1.10.tgz",
+      "integrity": "sha512-qoOjJYXUF9wRHHnnaVgmXY2UVOqohY2eB/12JqUdCUAnrm76W1RLfQPk+9BiHKObknrgcWNIHj1nJz2FDtLgkw==",
       "requires": {
         "@babel/core": "^7.8.7",
         "@babel/generator": "^7.8.8",
@@ -8901,7 +9050,7 @@
         "escape-string-regexp": "^1.0.5",
         "eval": "^0.1.4",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.0.34",
+        "gatsby-core-utils": "^1.1.3",
         "gray-matter": "^4.0.2",
         "json5": "^2.1.2",
         "loader-utils": "^1.4.0",
@@ -8923,22 +9072,33 @@
         "unist-util-visit": "^1.4.1"
       },
       "dependencies": {
+        "@babel/compat-data": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.0.tgz",
+          "integrity": "sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==",
+          "requires": {
+            "browserslist": "^4.9.1",
+            "invariant": "^2.2.4",
+            "semver": "^5.5.0"
+          }
+        },
         "@babel/core": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.7.tgz",
-          "integrity": "sha512-rBlqF3Yko9cynC5CCFy6+K/w2N+Sq/ff2BPy+Krp7rHlABIr5epbA7OxVeKoMHB39LZOp1UY5SuLjy6uWi35yA==",
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+          "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
           "requires": {
             "@babel/code-frame": "^7.8.3",
-            "@babel/generator": "^7.8.7",
-            "@babel/helpers": "^7.8.4",
-            "@babel/parser": "^7.8.7",
+            "@babel/generator": "^7.9.0",
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helpers": "^7.9.0",
+            "@babel/parser": "^7.9.0",
             "@babel/template": "^7.8.6",
-            "@babel/traverse": "^7.8.6",
-            "@babel/types": "^7.8.7",
+            "@babel/traverse": "^7.9.0",
+            "@babel/types": "^7.9.0",
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.0",
+            "json5": "^2.1.2",
             "lodash": "^4.17.13",
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
@@ -8946,24 +9106,14 @@
           }
         },
         "@babel/generator": {
-          "version": "7.8.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
-          "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
+          "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
           "requires": {
-            "@babel/types": "^7.8.7",
+            "@babel/types": "^7.9.5",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.13",
             "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-call-delegate": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.8.7.tgz",
-          "integrity": "sha512-doAA5LAKhsFCR0LAFIf+r2RSMmC+m8f/oQ+URnUET/rWeEzC0yTRmAGyWkD4sSu3xwbS7MYQ2u+xlt1V5R56KQ==",
-          "requires": {
-            "@babel/helper-hoist-variables": "^7.8.3",
-            "@babel/traverse": "^7.8.3",
-            "@babel/types": "^7.8.7"
           }
         },
         "@babel/helper-compilation-targets": {
@@ -8976,32 +9126,133 @@
             "invariant": "^2.2.4",
             "levenary": "^1.1.1",
             "semver": "^5.5.0"
-          },
-          "dependencies": {
-            "browserslist": {
-              "version": "4.10.0",
-              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.10.0.tgz",
-              "integrity": "sha512-TpfK0TDgv71dzuTsEAlQiHeWQ/tiPqgNZVdv046fvNtBZrjbv2O3TsWCDU0AWGJJKCF/KsjNdLzR9hXOsh/CfA==",
-              "requires": {
-                "caniuse-lite": "^1.0.30001035",
-                "electron-to-chromium": "^1.3.378",
-                "node-releases": "^1.1.52",
-                "pkg-up": "^3.1.0"
-              }
-            }
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+          "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.9.5"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+          "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+          "requires": {
+            "@babel/helper-module-imports": "^7.8.3",
+            "@babel/helper-replace-supers": "^7.8.6",
+            "@babel/helper-simple-access": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/template": "^7.8.6",
+            "@babel/types": "^7.9.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+          "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+          "requires": {
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.9.0",
+            "@babel/types": "^7.9.0"
           }
         },
         "@babel/parser": {
-          "version": "7.8.8",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-          "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+          "version": "7.9.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+          "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+        },
+        "@babel/plugin-proposal-optional-chaining": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.9.0.tgz",
+          "integrity": "sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+          }
+        },
+        "@babel/plugin-transform-classes": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.5.tgz",
+          "integrity": "sha512-x2kZoIuLC//O5iA7PEvecB105o7TLzZo8ofBVhP79N+DO3jaX+KYfww9TQcfBEZD0nikNyYcGB1IKtRq36rdmg==",
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.8.3",
+            "@babel/helper-define-map": "^7.8.3",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-optimise-call-expression": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/helper-replace-supers": "^7.8.6",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/plugin-transform-destructuring": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.9.5.tgz",
+          "integrity": "sha512-j3OEsGel8nHL/iusv/mRd5fYZ3DrOxWC82x0ogmdN/vHfAP4MYw+AFKYanzWlktNwikKvlzUV//afBW5FTp17Q==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.3"
+          }
+        },
+        "@babel/plugin-transform-for-of": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.9.0.tgz",
+          "integrity": "sha512-lTAnWOpMwOXpyDx06N+ywmF3jNbafZEqZ96CGYabxHrxNX8l5ny7dt4bK/rGwAh9utyP2b2Hv7PlZh1AAS54FQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.3"
+          }
+        },
+        "@babel/plugin-transform-modules-amd": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz",
+          "integrity": "sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==",
+          "requires": {
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
+          }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
+          "integrity": "sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==",
+          "requires": {
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/helper-simple-access": "^7.8.3",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
+          }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz",
+          "integrity": "sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==",
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.8.3",
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "babel-plugin-dynamic-import-node": "^2.3.0"
+          }
+        },
+        "@babel/plugin-transform-modules-umd": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.9.0.tgz",
+          "integrity": "sha512-uTWkXkIVtg/JGRSIABdBoMsoIeoHQHPTL0Y2E7xf5Oj7sLqwVsNXOkNk0VJc7vF0IMBsPeikHxFjGe+qmwPtTQ==",
+          "requires": {
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helper-plugin-utils": "^7.8.3"
+          }
         },
         "@babel/plugin-transform-parameters": {
-          "version": "7.8.8",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.8.tgz",
-          "integrity": "sha512-hC4Ld/Ulpf1psQciWWwdnUspQoQco2bMzSrwU6TmzRlvoYQe4rQFy9vnCZDTlVeCQj0JPfL+1RX0V8hCJvkgBA==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.5.tgz",
+          "integrity": "sha512-0+1FhHnMfj6lIIhVvS4KGQJeuhe1GI//h5uptK4PvLt+BGBxsoUJbd3/IW002yk//6sZPlFgsG1hY6OHLcy6kA==",
           "requires": {
-            "@babel/helper-call-delegate": "^7.8.7",
             "@babel/helper-get-function-arity": "^7.8.3",
             "@babel/helper-plugin-utils": "^7.8.3"
           }
@@ -9015,11 +9266,11 @@
           }
         },
         "@babel/preset-env": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.7.tgz",
-          "integrity": "sha512-BYftCVOdAYJk5ASsznKAUl53EMhfBbr8CJ1X+AJLfGPscQkwJFiaV/Wn9DPH/7fzm2v6iRYJKYHSqyynTGw0nw==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.5.tgz",
+          "integrity": "sha512-eWGYeADTlPJH+wq1F0wNfPbVS1w1wtmMJiYk55Td5Yu28AsdR9AsC97sZ0Qq8fHqQuslVSIYSGJMcblr345GfQ==",
           "requires": {
-            "@babel/compat-data": "^7.8.6",
+            "@babel/compat-data": "^7.9.0",
             "@babel/helper-compilation-targets": "^7.8.7",
             "@babel/helper-module-imports": "^7.8.3",
             "@babel/helper-plugin-utils": "^7.8.3",
@@ -9027,14 +9278,16 @@
             "@babel/plugin-proposal-dynamic-import": "^7.8.3",
             "@babel/plugin-proposal-json-strings": "^7.8.3",
             "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-            "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+            "@babel/plugin-proposal-numeric-separator": "^7.8.3",
+            "@babel/plugin-proposal-object-rest-spread": "^7.9.5",
             "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
-            "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+            "@babel/plugin-proposal-optional-chaining": "^7.9.0",
             "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
             "@babel/plugin-syntax-async-generators": "^7.8.0",
             "@babel/plugin-syntax-dynamic-import": "^7.8.0",
             "@babel/plugin-syntax-json-strings": "^7.8.0",
             "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+            "@babel/plugin-syntax-numeric-separator": "^7.8.0",
             "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
             "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
             "@babel/plugin-syntax-optional-chaining": "^7.8.0",
@@ -9043,24 +9296,24 @@
             "@babel/plugin-transform-async-to-generator": "^7.8.3",
             "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
             "@babel/plugin-transform-block-scoping": "^7.8.3",
-            "@babel/plugin-transform-classes": "^7.8.6",
+            "@babel/plugin-transform-classes": "^7.9.5",
             "@babel/plugin-transform-computed-properties": "^7.8.3",
-            "@babel/plugin-transform-destructuring": "^7.8.3",
+            "@babel/plugin-transform-destructuring": "^7.9.5",
             "@babel/plugin-transform-dotall-regex": "^7.8.3",
             "@babel/plugin-transform-duplicate-keys": "^7.8.3",
             "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-            "@babel/plugin-transform-for-of": "^7.8.6",
+            "@babel/plugin-transform-for-of": "^7.9.0",
             "@babel/plugin-transform-function-name": "^7.8.3",
             "@babel/plugin-transform-literals": "^7.8.3",
             "@babel/plugin-transform-member-expression-literals": "^7.8.3",
-            "@babel/plugin-transform-modules-amd": "^7.8.3",
-            "@babel/plugin-transform-modules-commonjs": "^7.8.3",
-            "@babel/plugin-transform-modules-systemjs": "^7.8.3",
-            "@babel/plugin-transform-modules-umd": "^7.8.3",
+            "@babel/plugin-transform-modules-amd": "^7.9.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.9.0",
+            "@babel/plugin-transform-modules-systemjs": "^7.9.0",
+            "@babel/plugin-transform-modules-umd": "^7.9.0",
             "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
             "@babel/plugin-transform-new-target": "^7.8.3",
             "@babel/plugin-transform-object-super": "^7.8.3",
-            "@babel/plugin-transform-parameters": "^7.8.7",
+            "@babel/plugin-transform-parameters": "^7.9.5",
             "@babel/plugin-transform-property-literals": "^7.8.3",
             "@babel/plugin-transform-regenerator": "^7.8.7",
             "@babel/plugin-transform-reserved-words": "^7.8.3",
@@ -9070,28 +9323,68 @@
             "@babel/plugin-transform-template-literals": "^7.8.3",
             "@babel/plugin-transform-typeof-symbol": "^7.8.4",
             "@babel/plugin-transform-unicode-regex": "^7.8.3",
-            "@babel/types": "^7.8.7",
-            "browserslist": "^4.8.5",
+            "@babel/preset-modules": "^0.1.3",
+            "@babel/types": "^7.9.5",
+            "browserslist": "^4.9.1",
             "core-js-compat": "^3.6.2",
             "invariant": "^2.2.2",
             "levenary": "^1.1.1",
             "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "@babel/plugin-proposal-object-rest-spread": {
+              "version": "7.9.5",
+              "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz",
+              "integrity": "sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==",
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                "@babel/plugin-transform-parameters": "^7.9.5"
+              }
+            }
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+          "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.5",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.9.0",
+            "@babel/types": "^7.9.5",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
           }
         },
         "@babel/types": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-          "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+          "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
           "requires": {
-            "esutils": "^2.0.2",
+            "@babel/helper-validator-identifier": "^7.9.5",
             "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
         },
+        "browserslist": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
+          "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001043",
+            "electron-to-chromium": "^1.3.413",
+            "node-releases": "^1.1.53",
+            "pkg-up": "^2.0.0"
+          }
+        },
         "caniuse-lite": {
-          "version": "1.0.30001035",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
-          "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ=="
+          "version": "1.0.30001045",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001045.tgz",
+          "integrity": "sha512-Y8o2Iz1KPcD6FjySbk1sPpvJqchgxk/iow0DABpGyzA1UeQAuxh63Xh0Enj5/BrsYbXtCN32JmR4ZxQTCQ6E6A=="
         },
         "configstore": {
           "version": "5.0.1",
@@ -9120,14 +9413,22 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.379",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.379.tgz",
-          "integrity": "sha512-NK9DBBYEBb5f9D7zXI0hiE941gq3wkBeQmXs1ingigA/jnTg5mhwY2Z5egwA+ZI8OLGKCx0h1Cl8/xeuIBuLlg=="
+          "version": "1.3.414",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.414.tgz",
+          "integrity": "sha512-UfxhIvED++qLwWrAq9uYVcqF8FdeV9sU2S7qhiHYFODxzXRrd1GZRl/PjITHsTEejgibcWDraD8TQqoHb1aCBQ=="
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
         },
         "gatsby-core-utils": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.34.tgz",
-          "integrity": "sha512-CVuUQTVY+0X7vAqFnDeRT0ZkN0tUXvk6GLvUqfmoOzBvX9HphiR0VTi1tEYrsc5DSaz7Oyhr0vdp8j/e96rH1w==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.1.3.tgz",
+          "integrity": "sha512-PntSiNCFo1/ZKjp00qgLBj2jdwY7M+maV21RXb1k7Ud9Vv9j0dGQsaVb9YXFTqXAf8bG0Xyqsqq4mPU1iNYLDw==",
           "requires": {
             "ci-info": "2.0.0",
             "configstore": "^5.0.1",
@@ -9140,17 +9441,26 @@
           "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         },
         "json5": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
-          "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "requires": {
             "minimist": "^1.2.5"
           }
         },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "requires": {
             "semver": "^6.0.0"
           },
@@ -9168,18 +9478,37 @@
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "node-releases": {
-          "version": "1.1.52",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
-          "integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
+          "version": "1.1.53",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+          "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "requires": {
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            }
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
+        "pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+          "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+          "requires": {
+            "find-up": "^2.1.0"
           }
         },
         "regenerator-transform": {
@@ -9191,6 +9520,18 @@
             "private": "^0.1.8"
           }
         },
+        "unified": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+          "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^2.0.0",
+            "trough": "^1.0.0",
+            "vfile": "^4.0.0"
+          }
+        },
         "unique-string": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -9199,12 +9540,28 @@
             "crypto-random-string": "^2.0.0"
           }
         },
+        "unist-util-remove": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-1.0.3.tgz",
+          "integrity": "sha512-mB6nCHCQK0pQffUAcCVmKgIWzG/AXs/V8qpS8K72tMPtOSCMSjDeMc5yN+Ye8rB0FhcE+JvW++o1xRNc0R+++g==",
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        },
         "unist-util-visit": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
           "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
           "requires": {
             "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "requires": {
+            "unist-util-is": "^3.0.0"
           }
         },
         "write-file-atomic": {
@@ -9240,17 +9597,17 @@
       }
     },
     "gatsby-plugin-react-helmet": {
-      "version": "3.1.24",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.1.24.tgz",
-      "integrity": "sha512-kLR/RMDBVriJptsJufoL1UBVHgq2fZIMXen7nru2ugGn0m8xwpArFoOz6meYlpiDB3Z41eYR/+Nr8GizQnYcxg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.2.4.tgz",
+      "integrity": "sha512-AHmmhodv7E8+qkHC5W0XSTgoQb1iHMB15Jn4NnEnDz696pZ448g1MCnX3bEMGCjYg2wHKJlo29EVoa4z5dS5lw==",
       "requires": {
         "@babel/runtime": "^7.8.7"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -9263,17 +9620,17 @@
       }
     },
     "gatsby-plugin-remove-trailing-slashes": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-remove-trailing-slashes/-/gatsby-plugin-remove-trailing-slashes-2.1.24.tgz",
-      "integrity": "sha512-4YZ+7JdQCxiaEPuFtGPMXYsg8LHJ+BdTWNex+dGA82AniaF5yn2ZAcMLbNelD71MVTjw2IYtyPJjgLZz6f5W2A==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-remove-trailing-slashes/-/gatsby-plugin-remove-trailing-slashes-2.2.3.tgz",
+      "integrity": "sha512-3m1JT4Hk4vLVcHElE3Oj2k38QC+Nh1e+dsNRAdNov9hgjNSmP6/xhXqDCbi7fpAu0vOwoP5HFe2XAbCYtf74rw==",
       "requires": {
         "@babel/runtime": "^7.8.7"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -9286,17 +9643,17 @@
       }
     },
     "gatsby-plugin-styled-components": {
-      "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-styled-components/-/gatsby-plugin-styled-components-3.1.21.tgz",
-      "integrity": "sha512-uU4MtUAw3zazeVnKnOL0c0+mhtpNfEKee983jyUnAGZnXyXa9EYfZ7Lw+b++FqCce+e6EDlI7VemUR4voSD0DQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-styled-components/-/gatsby-plugin-styled-components-3.2.3.tgz",
+      "integrity": "sha512-3t7DWz57T52huhBnaXny8R2jhXbvKBWQjA4CMOtauTRzopGLgJf90y4f81arqrhnyyTm8rmX8NI1PzAt8RJomg==",
       "requires": {
         "@babel/runtime": "^7.8.7"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -9329,9 +9686,9 @@
       }
     },
     "gatsby-source-filesystem": {
-      "version": "2.1.57",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.57.tgz",
-      "integrity": "sha512-HBD1wFoCpVXYLwL3Wwyz6d2E/ff7DDy81YrmCzXTJmAsGmVXraJZkUAbxwuqt3L793e8SHBd6yVi+wBKRowBXg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.2.4.tgz",
+      "integrity": "sha512-Tf5HKAYcVmVFj7DhWi7+opDH312em8vkuoH/fTVLReBrN0yfi8maDha9EaZj4lL1fTtLk6WG0TwOM6GkyYiqgw==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "better-queue": "^3.8.10",
@@ -9339,8 +9696,8 @@
         "chokidar": "3.3.1",
         "file-type": "^12.4.2",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.0.34",
-        "got": "^8.3.2",
+        "gatsby-core-utils": "^1.1.3",
+        "got": "^9.6.0",
         "md5-file": "^3.2.3",
         "mime": "^2.4.4",
         "pretty-bytes": "^5.3.0",
@@ -9351,11 +9708,45 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@sindresorhus/is": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+          "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+        },
+        "cacheable-request": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+          "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+          "requires": {
+            "clone-response": "^1.0.2",
+            "get-stream": "^5.1.0",
+            "http-cache-semantics": "^4.0.0",
+            "keyv": "^3.0.0",
+            "lowercase-keys": "^2.0.0",
+            "normalize-url": "^4.1.0",
+            "responselike": "^1.0.2"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+              "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            },
+            "lowercase-keys": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+              "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+            }
           }
         },
         "chokidar": {
@@ -9391,6 +9782,14 @@
           "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
           "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
         },
+        "decompress-response": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+          "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
         "dot-prop": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
@@ -9400,14 +9799,45 @@
           }
         },
         "gatsby-core-utils": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.34.tgz",
-          "integrity": "sha512-CVuUQTVY+0X7vAqFnDeRT0ZkN0tUXvk6GLvUqfmoOzBvX9HphiR0VTi1tEYrsc5DSaz7Oyhr0vdp8j/e96rH1w==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.1.3.tgz",
+          "integrity": "sha512-PntSiNCFo1/ZKjp00qgLBj2jdwY7M+maV21RXb1k7Ud9Vv9j0dGQsaVb9YXFTqXAf8bG0Xyqsqq4mPU1iNYLDw==",
           "requires": {
             "ci-info": "2.0.0",
             "configstore": "^5.0.1",
             "node-object-hash": "^2.0.0"
           }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          }
+        },
+        "http-cache-semantics": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+          "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
         },
         "is-obj": {
           "version": "2.0.0",
@@ -9415,12 +9845,27 @@
           "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         },
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "requires": {
             "semver": "^6.0.0"
           }
+        },
+        "mimic-response": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+        },
+        "normalize-url": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+        },
+        "p-cancelable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+          "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
         },
         "readdirp": {
           "version": "3.3.0",
@@ -9465,9 +9910,9 @@
           "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
         },
         "xstate": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.8.0.tgz",
-          "integrity": "sha512-xHSYQtCHLkcrFRxa5lK4Lp1rnKt00a80jcKFMQiMBuE+6MvTYv7twwqYpzjsJoKFjGZB3GGEpZAuY1dmlPTh/g=="
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.9.1.tgz",
+          "integrity": "sha512-cfNnRaBebnr1tvs0nHBUTyomfJx36+8MWwXceyNTZfjyELMM8nIoiBDcUzfKmpNlnAvs2ZPREos19cw6Zl4nng=="
         }
       }
     },
@@ -9581,9 +10026,9 @@
       }
     },
     "gatsby-transformer-yaml": {
-      "version": "2.2.27",
-      "resolved": "https://registry.npmjs.org/gatsby-transformer-yaml/-/gatsby-transformer-yaml-2.2.27.tgz",
-      "integrity": "sha512-PRhVKk1Ac6lHX2gyekMwJt2rifmsKXM2QeKaL5iAEk4JLoB/jSJ+muYqAMgh/hIHVBNn4J8h80UwlhevTiiFJA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-yaml/-/gatsby-transformer-yaml-2.3.3.tgz",
+      "integrity": "sha512-tyySuF9hPe2Bug1TAwfALLq2w3GxWw4vKQOpJKIbAd1d0HA6oBH9Xri309PQuG3TDtiylv4lygWDGXYUP6+x6Q==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "js-yaml": "^3.13.1",
@@ -9592,9 +10037,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -9640,6 +10085,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz",
       "integrity": "sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ=="
+    },
+    "get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
     },
     "get-pkg-repo": {
       "version": "4.1.0",
@@ -10146,17 +10596,17 @@
       "integrity": "sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA=="
     },
     "hast-util-raw": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-5.0.1.tgz",
-      "integrity": "sha512-iHo7G6BjRc/GU1Yun5CIEXjil0wVnIbz11C6k0JdDichSDMtYi2+NNtk6YN7EOP0JfPstX30d3pRLfaJv5CkdA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-5.0.2.tgz",
+      "integrity": "sha512-3ReYQcIHmzSgMq8UrDZHFL0oGlbuVGdLKs8s/Fe8BfHFAyZDrdv1fy/AGn+Fim8ZuvAHcJ61NQhVMtyfHviT/g==",
       "requires": {
         "hast-util-from-parse5": "^5.0.0",
         "hast-util-to-parse5": "^5.0.0",
-        "html-void-elements": "^1.0.1",
+        "html-void-elements": "^1.0.0",
         "parse5": "^5.0.0",
         "unist-util-position": "^3.0.0",
         "web-namespaces": "^1.0.0",
-        "xtend": "^4.0.1",
+        "xtend": "^4.0.0",
         "zwitch": "^1.0.0"
       }
     },
@@ -10283,9 +10733,9 @@
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "html-escaper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
-      "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
     "html-react-parser": {
       "version": "0.9.2",
@@ -11278,9 +11728,9 @@
       }
     },
     "is-what": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.7.1.tgz",
-      "integrity": "sha512-IAoapxlqyLSqt0Zr/7ZMT/fjEw9nwxxmz/TlBH+TJjvcXxmmAdRvo41W74uw3XJMGFpbeft97cpkPmLK89lJWw=="
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.8.0.tgz",
+      "integrity": "sha512-UKeBoQfV8bjlM4pmx1FLDHdxslW/1mTksEs8ReVsilPmUv5cORd4+2/wFcviI3cUjrLybxCjzc8DnodAzJ/Wrg=="
     },
     "is-whitespace-character": {
       "version": "1.0.4",
@@ -13427,11 +13877,11 @@
       }
     },
     "mdast-squeeze-paragraphs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-3.0.5.tgz",
-      "integrity": "sha512-xX6Vbe348Y/rukQlG4W3xH+7v4ZlzUbSY4HUIQCuYrF2DrkcHx584mCaFxkWoDZKNUfyLZItHC9VAqX3kIP7XA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-4.0.0.tgz",
+      "integrity": "sha512-zxdPn69hkQ1rm4J+2Cs2j6wDEv7O17TfXTJ33tl/+JPIoEmtV9t2ZzBM5LPHE8QlHsmVD8t3vPKCyY3oH+H8MQ==",
       "requires": {
-        "unist-util-remove": "^1.0.0"
+        "unist-util-remove": "^2.0.0"
       }
     },
     "mdast-util-compact": {
@@ -13449,36 +13899,34 @@
           "requires": {
             "unist-util-visit-parents": "^2.0.0"
           }
-        }
-      }
-    },
-    "mdast-util-definitions": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
-      "integrity": "sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==",
-      "requires": {
-        "unist-util-visit": "^1.0.0"
-      },
-      "dependencies": {
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
           "requires": {
-            "unist-util-visit-parents": "^2.0.0"
+            "unist-util-is": "^3.0.0"
           }
         }
       }
     },
+    "mdast-util-definitions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-2.0.1.tgz",
+      "integrity": "sha512-Co+DQ6oZlUzvUR7JCpP249PcexxygiaKk9axJh+eRzHDZJk2julbIdKB4PXHVxdBuLzvJ1Izb+YDpj2deGMOuA==",
+      "requires": {
+        "unist-util-visit": "^2.0.0"
+      }
+    },
     "mdast-util-to-hast": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-7.0.0.tgz",
-      "integrity": "sha512-vxnXKSZgvPG2grZM3kxaF052pxsLtq8TPAkiMkqYj1nFTOazYUPXt3LFYIEB6Ws/IX7Uyvljzk64kD6DwZl/wQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-8.2.0.tgz",
+      "integrity": "sha512-WjH/KXtqU66XyTJQ7tg7sjvTw1OQcVV0hKdFh3BgHPwZ96fSBCQ/NitEHsN70Mmnggt+5eUUC7pCnK+2qGQnCA==",
       "requires": {
         "collapse-white-space": "^1.0.0",
         "detab": "^2.0.0",
-        "mdast-util-definitions": "^1.2.0",
-        "mdurl": "^1.0.1",
+        "mdast-util-definitions": "^2.0.0",
+        "mdurl": "^1.0.0",
         "trim-lines": "^1.0.0",
         "unist-builder": "^2.0.0",
         "unist-util-generated": "^1.0.0",
@@ -13495,6 +13943,13 @@
         "repeat-string": "^1.5.2",
         "unist-util-position": "^3.0.0",
         "vfile-location": "^2.0.0"
+      },
+      "dependencies": {
+        "vfile-location": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+          "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
+        }
       }
     },
     "mdast-util-to-string": {
@@ -13524,6 +13979,21 @@
           "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
           "requires": {
             "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          },
+          "dependencies": {
+            "unist-util-is": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+              "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+            }
           }
         }
       }
@@ -14062,6 +14532,11 @@
         }
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
+      "integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g=="
+    },
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
@@ -14122,7 +14597,8 @@
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "optional": true
     },
     "nanoid": {
       "version": "2.1.4",
@@ -14210,12 +14686,17 @@
       }
     },
     "node-abi": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
-      "integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.16.0.tgz",
+      "integrity": "sha512-+sa0XNlWDA6T+bDLmkCUYn6W5k5W6BPRL6mqzSCs6H/xUgtl4D5x2fORKDzopKiU6wsyn/+wXlRXwXeSp+mtoA==",
       "requires": {
         "semver": "^5.4.1"
       }
+    },
+    "node-addon-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
+      "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -14983,9 +15464,9 @@
       }
     },
     "parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
       "requires": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -16149,9 +16630,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -16646,16 +17127,72 @@
       }
     },
     "react-focus-on": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.3.0.tgz",
-      "integrity": "sha512-Qbgg2A0YwVuY2g3l5yazzTlHrOC6L4a1P2advANQmdXo7xeAokV5RCtk4sqT0ZoW81LU8IAJCsYzqIdXBBclGg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.4.1.tgz",
+      "integrity": "sha512-KGRIl0iAu+1k1dcX7eQCXF5ZR/nl+XyXN5Ukw/OY80vLaK2b6vDzNqnX0HdYbY5xSUhIRUvMWEzSsdEyPjvk/Q==",
       "requires": {
         "aria-hidden": "^1.1.1",
-        "react-focus-lock": "^2.2.1",
-        "react-remove-scroll": "^2.2.0",
-        "react-style-singleton": "^2.0.0",
-        "use-callback-ref": "^1.2.1",
+        "react-focus-lock": "^2.3.1",
+        "react-remove-scroll": "^2.3.0",
+        "react-style-singleton": "^2.1.0",
+        "use-callback-ref": "^1.2.3",
         "use-sidecar": "^1.0.1"
+      },
+      "dependencies": {
+        "focus-lock": {
+          "version": "0.6.7",
+          "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.7.tgz",
+          "integrity": "sha512-KRo93U/afEqt7w5tBm4t0FHf/Li8tEYav3n4GUiZdeRlRfrtMbL8yQg0xRVnY/kmBRmQ4xkqIlbaMvuqlu53kg=="
+        },
+        "react-focus-lock": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.3.1.tgz",
+          "integrity": "sha512-j15cWLPzH0gOmRrUg01C09Peu8qbcdVqr6Bjyfxj80cNZmH+idk/bNBYEDSmkAtwkXI+xEYWSmHYqtaQhZ8iUQ==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "focus-lock": "^0.6.7",
+            "prop-types": "^15.6.2",
+            "react-clientside-effect": "^1.2.2",
+            "use-callback-ref": "^1.2.1",
+            "use-sidecar": "^1.0.1"
+          }
+        },
+        "react-remove-scroll": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.3.0.tgz",
+          "integrity": "sha512-UqVimLeAe+5EHXKfsca081hAkzg3WuDmoT9cayjBegd6UZVhlTEchleNp9J4TMGkb/ftLve7ARB5Wph+HJ7A5g==",
+          "requires": {
+            "react-remove-scroll-bar": "^2.1.0",
+            "react-style-singleton": "^2.1.0",
+            "tslib": "^1.0.0",
+            "use-callback-ref": "^1.2.3",
+            "use-sidecar": "^1.0.1"
+          }
+        },
+        "react-remove-scroll-bar": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.1.0.tgz",
+          "integrity": "sha512-5X5Y5YIPjIPrAoMJxf6Pfa7RLNGCgwZ95TdnVPgPuMftRfO8DaC7F4KP1b5eiO8hHbe7u+wZNDbYN5WUTpv7+g==",
+          "requires": {
+            "react-style-singleton": "^2.1.0",
+            "tslib": "^1.0.0"
+          }
+        },
+        "react-style-singleton": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.0.tgz",
+          "integrity": "sha512-DH4ED+YABC1dhvSDYGGreAHmfuTXj6+ezT3CmHoqIEfxNgEYfIMoOtmbRp42JsUst3IPqBTDL+8r4TF7EWhIHw==",
+          "requires": {
+            "get-nonce": "^1.0.0",
+            "invariant": "^2.2.4",
+            "tslib": "^1.0.0"
+          }
+        },
+        "use-callback-ref": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.3.tgz",
+          "integrity": "sha512-DPBPh1i2adCZoIArRlTuKRy7yue7QogtEnfv0AKrWsY+GA+4EKe37zhRDouNnyWMoNQFYZZRF+2dLHsWE4YvJA=="
+        }
       }
     },
     "react-frame-component": {
@@ -17094,6 +17631,19 @@
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
         },
+        "parse-entities": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        },
         "remark-parse": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
@@ -17131,10 +17681,34 @@
             "x-is-string": "^0.1.0"
           }
         },
+        "unist-util-remove-position": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+          "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
+          "requires": {
+            "unist-util-visit": "^1.1.0"
+          }
+        },
         "unist-util-stringify-position": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
           "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+        },
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
         },
         "vfile": {
           "version": "3.0.1",
@@ -17147,6 +17721,11 @@
             "vfile-message": "^1.0.0"
           }
         },
+        "vfile-location": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+          "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
+        },
         "vfile-message": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
@@ -17157,40 +17736,179 @@
         }
       }
     },
+    "remark-footnotes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-1.0.0.tgz",
+      "integrity": "sha512-X9Ncj4cj3/CIvLI2Z9IobHtVi8FVdUrdJkCNaL9kdX8ohfsi18DXHsCVd/A7ssARBdccdDb5ODnt62WuEWaM/g=="
+    },
     "remark-mdx": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.5.7.tgz",
-      "integrity": "sha512-f13ot+zaByDXYuOC4FWTpQCGP/rNbaxdhs2mLlW7ZBipm3JYR2ASFSL7RC3R7ytzm3n8v6hhcFxDKU+CwC2f4g==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.5.9.tgz",
+      "integrity": "sha512-HFr/VOVoJ2lnZsN090wttFTcqXIker49S5JT3Tem8SKMeQoRA9Pl+iIlEOZau+C9w6ISZj79l6nwzrflAa5VDA==",
       "requires": {
-        "@babel/core": "7.8.4",
+        "@babel/core": "7.9.0",
         "@babel/helper-plugin-utils": "7.8.3",
-        "@babel/plugin-proposal-object-rest-spread": "7.8.3",
+        "@babel/plugin-proposal-object-rest-spread": "7.9.5",
         "@babel/plugin-syntax-jsx": "7.8.3",
-        "@mdx-js/util": "^1.5.7",
+        "@mdx-js/util": "^1.5.9",
         "is-alphabetical": "1.0.4",
-        "remark-parse": "7.0.2",
-        "unified": "8.4.2"
+        "remark-parse": "8.0.1",
+        "unified": "9.0.0"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+          "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.0",
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helpers": "^7.9.0",
+            "@babel/parser": "^7.9.0",
+            "@babel/template": "^7.8.6",
+            "@babel/traverse": "^7.9.0",
+            "@babel/types": "^7.9.0",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
+          "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+          "requires": {
+            "@babel/types": "^7.9.5",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+          "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.9.5"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+          "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+          "requires": {
+            "@babel/helper-module-imports": "^7.8.3",
+            "@babel/helper-replace-supers": "^7.8.6",
+            "@babel/helper-simple-access": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/template": "^7.8.6",
+            "@babel/types": "^7.9.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+          "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+          "requires": {
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.9.0",
+            "@babel/types": "^7.9.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.9.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+          "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz",
+          "integrity": "sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+            "@babel/plugin-transform-parameters": "^7.9.5"
+          }
+        },
+        "@babel/plugin-transform-parameters": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.5.tgz",
+          "integrity": "sha512-0+1FhHnMfj6lIIhVvS4KGQJeuhe1GI//h5uptK4PvLt+BGBxsoUJbd3/IW002yk//6sZPlFgsG1hY6OHLcy6kA==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+          "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.5",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.9.0",
+            "@babel/types": "^7.9.5",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+          "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        }
       }
     },
     "remark-parse": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.2.tgz",
-      "integrity": "sha512-9+my0lQS80IQkYXsMA8Sg6m9QfXYJBnXjWYN5U+kFc5/n69t+XZVXU/ZBYr3cYH8FheEGf1v87rkFDhJ8bVgMA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.1.tgz",
+      "integrity": "sha512-Ye/5W57tdQZWsfkuVyRq9SUWRgECHnDsMuyUMzdSKpTbNPkZeGtoYfsrkeSi4+Xyl0mhcPPddHITXPcCPHrl3w==",
       "requires": {
+        "ccount": "^1.0.0",
         "collapse-white-space": "^1.0.2",
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0",
         "is-whitespace-character": "^1.0.0",
         "is-word-character": "^1.0.0",
         "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.1.0",
+        "parse-entities": "^2.0.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
         "trim": "0.0.1",
         "trim-trailing-lines": "^1.0.0",
         "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
+        "unist-util-remove-position": "^2.0.0",
+        "vfile-location": "^3.0.0",
         "xtend": "^4.0.1"
       }
     },
@@ -17203,11 +17921,11 @@
       }
     },
     "remark-squeeze-paragraphs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-3.0.4.tgz",
-      "integrity": "sha512-Wmz5Yj9q+W1oryo8BV17JrOXZgUKVcpJ2ApE2pwnoHwhFKSk4Wp2PmFNbmJMgYSqAdFwfkoe+TSYop5Fy8wMgA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-4.0.0.tgz",
+      "integrity": "sha512-8qRqmL9F4nuLPIgl92XUuxI3pFxize+F1H0e/W3llTk0UsjJaj01+RrirkMw7P21RKe4X6goQhYRSvNWX+70Rw==",
       "requires": {
-        "mdast-squeeze-paragraphs": "^3.0.0"
+        "mdast-squeeze-paragraphs": "^4.0.0"
       }
     },
     "remark-stringify": {
@@ -17229,6 +17947,21 @@
         "stringify-entities": "^1.0.1",
         "unherit": "^1.0.4",
         "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "parse-entities": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        }
       }
     },
     "remove-trailing-separator": {
@@ -17832,25 +18565,25 @@
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "sharp": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.23.4.tgz",
-      "integrity": "sha512-fJMagt6cT0UDy9XCsgyLi0eiwWWhQRxbwGmqQT6sY8Av4s0SVsT/deg8fobBQCTDU5iXRgz0rAeXoE2LBZ8g+Q==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.25.2.tgz",
+      "integrity": "sha512-l1GN0kFNtJr3U9i9pt7a+vo2Ij0xv4tTKDIPx8W6G9WELhPwrMyZZJKAAQNBSI785XB4uZfS5Wpz8C9jWV4AFQ==",
       "requires": {
         "color": "^3.1.2",
         "detect-libc": "^1.0.3",
-        "nan": "^2.14.0",
+        "node-addon-api": "^2.0.0",
         "npmlog": "^4.1.2",
         "prebuild-install": "^5.3.3",
-        "semver": "^6.3.0",
+        "semver": "^7.1.3",
         "simple-get": "^3.1.0",
-        "tar": "^5.0.5",
+        "tar": "^6.0.1",
         "tunnel-agent": "^0.6.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         }
       }
     },
@@ -18810,9 +19543,9 @@
       }
     },
     "stylefire": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-7.0.2.tgz",
-      "integrity": "sha512-LFIBP6fIA+EMqLSvM4V6zLa+O/iAcHoNJVuXkkZ5G8+T+Pd3KaQLqgxrpkeo1bwWQHqzgab8U3V3gudO231fZA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-7.0.3.tgz",
+      "integrity": "sha512-Q0l7NSeFz/OkX+o6/7Zg3VZxSAZeQzQpYomWmIpOehFM/rJNMSLVX5fgg6Q48ut2ETNKwdhm97mPNU643EBCoQ==",
       "requires": {
         "@popmotion/popcorn": "^0.4.4",
         "framesync": "^4.0.0",
@@ -19005,25 +19738,32 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "tar": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.5.tgz",
-      "integrity": "sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.1.tgz",
+      "integrity": "sha512-bKhKrrz2FJJj5s7wynxy/fyxpE0CmCjmOQ1KV4KkgXFWOgoIT/NbTMnB1n+LFNrNk0SSBVGGxcK5AGsyC+pW5Q==",
       "requires": {
         "chownr": "^1.1.3",
         "fs-minipass": "^2.0.0",
         "minipass": "^3.0.0",
         "minizlib": "^2.1.0",
-        "mkdirp": "^0.5.0",
+        "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        }
       }
     },
     "tar-fs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
-      "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+      "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
       "requires": {
         "chownr": "^1.1.1",
-        "mkdirp": "^0.5.1",
+        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
         "tar-stream": "^2.0.0"
       }
@@ -19565,12 +20305,13 @@
       }
     },
     "unified": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-      "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-9.0.0.tgz",
+      "integrity": "sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==",
       "requires": {
         "bail": "^1.0.0",
         "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
         "is-plain-obj": "^2.0.0",
         "trough": "^1.0.0",
         "vfile": "^4.0.0"
@@ -19658,29 +20399,26 @@
       "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA=="
     },
     "unist-util-remove": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-1.0.3.tgz",
-      "integrity": "sha512-mB6nCHCQK0pQffUAcCVmKgIWzG/AXs/V8qpS8K72tMPtOSCMSjDeMc5yN+Ye8rB0FhcE+JvW++o1xRNc0R+++g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-2.0.0.tgz",
+      "integrity": "sha512-HwwWyNHKkeg/eXRnE11IpzY8JT55JNM1YCwwU9YNCnfzk6s8GhPXrVBBZWiwLeATJbI7euvoGSzcy9M29UeW3g==",
       "requires": {
-        "unist-util-is": "^3.0.0"
+        "unist-util-is": "^4.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
+          "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
+        }
       }
     },
     "unist-util-remove-position": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
-      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-2.0.1.tgz",
+      "integrity": "sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==",
       "requires": {
-        "unist-util-visit": "^1.1.0"
-      },
-      "dependencies": {
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        }
+        "unist-util-visit": "^2.0.0"
       }
     },
     "unist-util-select": {
@@ -19730,15 +20468,6 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
           "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
-        },
-        "unist-util-visit-parents": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
-          "integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^4.0.0"
-          }
         }
       }
     },
@@ -19748,11 +20477,19 @@
       "integrity": "sha512-sA/nXwYRCQVRwZU2/tQWUqJ9JSFM1X3x7JIOsIgSzrFHcfVt6NkzDtKzyxg2cZWkCwGF9CO8x4QNZRJRMK8FeQ=="
     },
     "unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
+      "integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
       "requires": {
-        "unist-util-is": "^3.0.0"
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
+          "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
+        }
       }
     },
     "universalify": {
@@ -20180,9 +20917,9 @@
       }
     },
     "vfile": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.3.tgz",
-      "integrity": "sha512-lREgT5sF05TQk68LO6APy0In+TkFGnFEgKChK2+PHIaTrFQ9oHCKXznZ7VILwgYVBcl0gv4lGATFZBLhi2kVQg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.0.tgz",
+      "integrity": "sha512-BaTPalregj++64xbGK6uIlsurN3BCRNM/P2Pg8HezlGzKd1O9PrwIac6bd9Pdx2uTb0QHoioZ+rXKolbVXEgJg==",
       "requires": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -20192,14 +20929,14 @@
       }
     },
     "vfile-location": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.0.1.tgz",
+      "integrity": "sha512-yYBO06eeN/Ki6Kh1QAkgzYpWT1d3Qln+ZCtSbJqFExPl1S3y2qqotJQXoh6qEvl/jDlgpUJolBn3PItVnnZRqQ=="
     },
     "vfile-message": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.3.tgz",
-      "integrity": "sha512-qQg/2z8qnnBHL0psXyF72kCjb9YioIynvyltuNKFaUhRtqTIcIMP3xnBaPzirVZNuBrUe1qwFciSx2yApa4byw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@primer/components": "^16.1.0",
-    "@primer/gatsby-theme-doctocat": "^0.18.0",
+    "@primer/gatsby-theme-doctocat": "^0.20.1",
     "blob-stream": "^0.1.3",
     "copy-to-clipboard": "^3.3.1",
     "downloadjs": "^1.4.7",

--- a/docs/src/components/icons.js
+++ b/docs/src/components/icons.js
@@ -1,5 +1,4 @@
-import {Box, Flex, Link, Text, TextInput} from '@primer/components'
-import {H3} from '@primer/gatsby-theme-doctocat/src/components/heading'
+import {Box, Flex, Grid, Heading, Link, Text, TextInput} from '@primer/components'
 import {Search} from '@primer/octicons-react'
 import {Link as GatsbyLink} from 'gatsby'
 import flatMap from 'lodash.flatmap'
@@ -28,7 +27,7 @@ export default function Icons() {
   const results = useSearch(iconsArray, query, {keys: ['name']})
   const iconsByHeight = React.useMemo(() => groupBy(results, 'height'), [results])
   return (
-    <>
+    <Grid gridGap={5}>
       <TextInput
         icon={Search}
         aria-label="Search"
@@ -36,15 +35,14 @@ export default function Icons() {
         onChange={event => setQuery(event.target.value)}
         placeholder="Search icons..."
         width="100%"
-        mb={5}
       />
       {Object.entries(iconsByHeight).length > 0 ? (
         Object.entries(iconsByHeight).map(([height, icons]) => (
           <Box key={height}>
-            <H3>
+            <Heading as="h2" fontSize={3} mb={3}>
               {height}
               px
-            </H3>
+            </Heading>
             <Flex flexWrap="wrap" mx={-3}>
               {icons.map(icon => (
                 <Link
@@ -68,6 +66,6 @@ export default function Icons() {
           No results found
         </Text>
       )}
-    </>
+    </Grid>
   )
 }

--- a/lib/octicons_jekyll/jekyll-octicons.gemspec
+++ b/lib/octicons_jekyll/jekyll-octicons.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "jekyll", ">= 3.6", "< 5.0"
-  s.add_dependency "octicons", "9.6.0"
+  s.add_dependency "octicons_v2", "10.0.0"
 end

--- a/lib/octicons_jekyll/lib/jekyll-octicons.rb
+++ b/lib/octicons_jekyll/lib/jekyll-octicons.rb
@@ -1,4 +1,4 @@
-require "octicons"
+require "octicons_v2"
 require "jekyll-octicons/version"
 require "liquid"
 require "jekyll/liquid_extensions"
@@ -31,7 +31,7 @@ module Jekyll
       prepare(interpolate(@markup, context)) if match = @markup.match(Variable)
 
       return nil if @symbol.nil?
-      ::Octicons::Octicon.new(@symbol, @options).to_svg
+      ::OcticonsV2::OcticonV2.new(@symbol, @options).to_svg
     end
 
     private

--- a/lib/octicons_jekyll/lib/jekyll-octicons/version.rb
+++ b/lib/octicons_jekyll/lib/jekyll-octicons/version.rb
@@ -3,6 +3,6 @@ module Liquid; class Tag; end; end
 
 module Jekyll
   class Octicons < Liquid::Tag
-    VERSION = "9.6.0".freeze
+    VERSION = "10.0.0".freeze
   end
 end

--- a/lib/octicons_jekyll/test/helper.rb
+++ b/lib/octicons_jekyll/test/helper.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require "jekyll-octicons_v2"
+require "jekyll-octicons"
 
 # Parse a string into a liquid template
 def parse(string)

--- a/lib/octicons_jekyll/test/helper.rb
+++ b/lib/octicons_jekyll/test/helper.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require "jekyll-octicons"
+require "jekyll-octicons_v2"
 
 # Parse a string into a liquid template
 def parse(string)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "9.6.0",
+  "version": "10.0.0",
   "scripts": {
     "version": "script/version",
     "test": "ava -v tests/*.js",


### PR DESCRIPTION
We currently have a website (https://primer.style/octicons) documenting our current octicons and another website (https://octicons-git-v2.primer.now.sh) documenting the new octicons. This PR updates the new octicons website to make it clear to visitors that they are viewing unreleased icons and that the documented packages are temporary. Here are the specific changes:

* Adds a banner on the homepage telling visitors that they are viewing unreleased icons:

  ![image](https://user-images.githubusercontent.com/4608155/80041429-50544800-84b1-11ea-8696-d96aee0b9d4e.png)

* Adds a banner on every package page telling visitors that the package is temporary:

  ![image](https://user-images.githubusercontent.com/4608155/80041501-7974d880-84b1-11ea-8e6b-68cd9eb9c5b5.png)

* Updates the documentation on each package page to use the correct package name:

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4608155/80041606-b6d96600-84b1-11ea-8fbb-5807f0536e9a.png) | ![image](https://user-images.githubusercontent.com/4608155/80041575-a45f2c80-84b1-11ea-94ec-9bb55f267d69.png) |

