### PR TITLE
Add UI examples on icon pages

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1529,34 +1529,172 @@
       }
     },
     "@primer/components": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@primer/components/-/components-16.1.0.tgz",
-      "integrity": "sha512-bSvrUYZkItgGAxnrYuIoeN9Cydd7HmAMQOrawsQ6NYPTlsDbZQKbmmew2cBf7mXA06KfJgj7CQdlE49faoW4lg==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@primer/components/-/components-19.0.0.tgz",
+      "integrity": "sha512-aWrO/ueicgCry3Uphbr4N+P9a5m9D6OyDwPvmF8BGLBWCJCplU7QhcWYdCqPqJX8FmmvuZv70EOUD8SmTHM4ww==",
       "requires": {
-        "@primer/octicons-react": "^9.2.0",
+        "@babel/helpers": "7.9.2",
+        "@babel/runtime": "7.9.2",
+        "@primer/octicons-react": "^9.6.0",
+        "@primer/primitives": "3.0.0",
         "@reach/dialog": "0.3.0",
+        "@styled-system/css": "5.1.5",
         "@styled-system/prop-types": "5.1.2",
         "@styled-system/props": "5.1.4",
         "@styled-system/theme-get": "5.1.2",
         "@testing-library/react": "9.4.0",
+        "@types/styled-components": "^4.4.0",
         "@types/styled-system": "5.1.2",
-        "babel-plugin-macros": "2.6.1",
+        "babel-plugin-macros": "2.8.0",
         "babel-polyfill": "6.26.0",
         "classnames": "^2.2.5",
         "details-element-polyfill": "2.4.0",
         "jest-axe": "3.2.0",
-        "nanoid": "2.1.4",
-        "primer-colors": "1.0.1",
-        "primer-typography": "1.0.1",
+        "polished": "3.5.2",
         "react": "^16.10.2",
         "react-is": "16.10.2",
         "styled-system": "5.1.2"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+          "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+          "requires": {
+            "@babel/types": "^7.9.6",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+          "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.9.5"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+          "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+          "requires": {
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.9.0",
+            "@babel/types": "^7.9.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+          "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q=="
+        },
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+          "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.6",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.9.6",
+            "@babel/types": "^7.9.6",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "babel-plugin-macros": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+          "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "cosmiconfig": "^6.0.0",
+            "resolve": "^1.12.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+        },
+        "polished": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/polished/-/polished-3.5.2.tgz",
+          "integrity": "sha512-vWoRDg3gY5RQBtUfcj9MRN10VCIf4EkdUikGxyXItg2Hnwk+eIVtdBiLajN0ldFeT3Vq4r/QNbjrQdhqBKrTug==",
+          "requires": {
+            "@babel/runtime": "^7.8.7"
+          }
+        },
         "react-is": {
           "version": "16.10.2",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
           "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         }
       }
     },
@@ -1613,6 +1751,38 @@
         "sentence-case": "^2.1.1",
         "styled-components": "^4.3.2",
         "styled-system": "^5.0.18"
+      },
+      "dependencies": {
+        "@primer/components": {
+          "version": "16.3.0",
+          "resolved": "https://registry.npmjs.org/@primer/components/-/components-16.3.0.tgz",
+          "integrity": "sha512-oydKIzcDCtIDjbGEUCLuxW94sDfBFbKRne/I4DlnYYnv6DGxpL1hE3zLoKp3+f5ycpsFSAckXJBafIhimQljpQ==",
+          "requires": {
+            "@primer/octicons-react": "^9.2.0",
+            "@reach/dialog": "0.3.0",
+            "@styled-system/prop-types": "5.1.2",
+            "@styled-system/props": "5.1.4",
+            "@styled-system/theme-get": "5.1.2",
+            "@testing-library/react": "9.4.0",
+            "@types/styled-system": "5.1.2",
+            "babel-plugin-macros": "2.6.1",
+            "babel-polyfill": "6.26.0",
+            "classnames": "^2.2.5",
+            "details-element-polyfill": "2.4.0",
+            "jest-axe": "3.2.0",
+            "nanoid": "2.1.4",
+            "primer-colors": "1.0.1",
+            "primer-typography": "1.0.1",
+            "react": "^16.10.2",
+            "react-is": "16.10.2",
+            "styled-system": "5.1.2"
+          }
+        },
+        "react-is": {
+          "version": "16.10.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+          "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+        }
       }
     },
     "@primer/octicons-react": {
@@ -1622,6 +1792,11 @@
       "requires": {
         "prop-types": "^15.6.1"
       }
+    },
+    "@primer/primitives": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-3.0.0.tgz",
+      "integrity": "sha512-ISXB43vcA+kg5pmGtGo3lPlHmY5Mg9nLhliePJu3Y5aP7g28TO+9cC99gL240pZHYsO0aVyU26WZwUXn6UIqJQ=="
     },
     "@reach/component-component": {
       "version": "0.3.0",
@@ -2001,6 +2176,15 @@
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
       "integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw=="
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -2089,10 +2273,29 @@
         "@types/react": "*"
       }
     },
+    "@types/react-native": {
+      "version": "0.62.7",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.62.7.tgz",
+      "integrity": "sha512-FGFEt9GcFVl//XxWmxkeBxAx0YnzyEhJpR8hOJrjfaFKZm0KjHzzyCmCksBAP2qHSTrcJCiBkIvYCX/kGiOgww==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+    },
+    "@types/styled-components": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-4.4.3.tgz",
+      "integrity": "sha512-U0udeNOZBfUkJycmGJwmzun0FBt11rZy08weVQmE2xfUNAbX8AGOEWxWna2d+qAUKxKgMlcG+TZT0+K2FfDcnQ==",
+      "requires": {
+        "@types/hoist-non-react-statics": "*",
+        "@types/react": "*",
+        "@types/react-native": "*",
+        "csstype": "^2.2.0"
+      }
     },
     "@types/styled-system": {
       "version": "5.1.2",
@@ -8162,9 +8365,9 @@
       }
     },
     "focus-lock": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.6.tgz",
-      "integrity": "sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw=="
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.8.tgz",
+      "integrity": "sha512-vkHTluRCoq9FcsrldC0ulQHiyBYgVJB2CX53I8r0nTC6KnEij7Of0jpBspjt3/CuNb6fyoj3aOh9J2HgQUM0og=="
     },
     "follow-redirects": {
       "version": "1.5.10",
@@ -17114,12 +17317,12 @@
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "react-focus-lock": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.2.1.tgz",
-      "integrity": "sha512-47g0xYcCTZccdzKRGufepY8oZ3W1Qg+2hn6u9SHZ0zUB6uz/4K4xJe7yYFNZ1qT6m+2JDm82F6QgKeBTbjW4PQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.3.1.tgz",
+      "integrity": "sha512-j15cWLPzH0gOmRrUg01C09Peu8qbcdVqr6Bjyfxj80cNZmH+idk/bNBYEDSmkAtwkXI+xEYWSmHYqtaQhZ8iUQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.6.6",
+        "focus-lock": "^0.6.7",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.2",
         "use-callback-ref": "^1.2.1",
@@ -17306,23 +17509,23 @@
       }
     },
     "react-remove-scroll": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.2.0.tgz",
-      "integrity": "sha512-bT29xAkNuhS2tnsxhLNJrmmb6Rn8VsnlOfSoRaKdKi90DbhRcQfJ9vHG1TtgfkCP+rx059vCGIScPZaCWsyIKA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.3.0.tgz",
+      "integrity": "sha512-UqVimLeAe+5EHXKfsca081hAkzg3WuDmoT9cayjBegd6UZVhlTEchleNp9J4TMGkb/ftLve7ARB5Wph+HJ7A5g==",
       "requires": {
-        "react-remove-scroll-bar": "^2.0.0",
-        "react-style-singleton": "^2.0.0",
+        "react-remove-scroll-bar": "^2.1.0",
+        "react-style-singleton": "^2.1.0",
         "tslib": "^1.0.0",
-        "use-callback-ref": "^1.2.1",
+        "use-callback-ref": "^1.2.3",
         "use-sidecar": "^1.0.1"
       }
     },
     "react-remove-scroll-bar": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.0.0.tgz",
-      "integrity": "sha512-HSdWZ+6vV6X1btLRhQlIcFulaMePCyg0Un2oXMmDdq8lK9KPUMSnWYINYWVCdgT35em9hiUaR8frBN1PYYLLpQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.1.0.tgz",
+      "integrity": "sha512-5X5Y5YIPjIPrAoMJxf6Pfa7RLNGCgwZ95TdnVPgPuMftRfO8DaC7F4KP1b5eiO8hHbe7u+wZNDbYN5WUTpv7+g==",
       "requires": {
-        "react-style-singleton": "^2.0.0",
+        "react-style-singleton": "^2.1.0",
         "tslib": "^1.0.0"
       }
     },
@@ -17340,10 +17543,11 @@
       "integrity": "sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA=="
     },
     "react-style-singleton": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.0.0.tgz",
-      "integrity": "sha512-1Kw9G/b7EqLspjtiKsC9jtoqkx+RAti+8PmBe47ioKTcdhB3gtaKw2Lc3Hsud/VrXh+QECZKmr2yDCwR7ObNtA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.0.tgz",
+      "integrity": "sha512-DH4ED+YABC1dhvSDYGGreAHmfuTXj6+ezT3CmHoqIEfxNgEYfIMoOtmbRp42JsUst3IPqBTDL+8r4TF7EWhIHw==",
       "requires": {
+        "get-nonce": "^1.0.0",
         "invariant": "^2.2.4",
         "tslib": "^1.0.0"
       }
@@ -20818,9 +21022,9 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "use-callback-ref": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.1.tgz",
-      "integrity": "sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.3.tgz",
+      "integrity": "sha512-DPBPh1i2adCZoIArRlTuKRy7yue7QogtEnfv0AKrWsY+GA+4EKe37zhRDouNnyWMoNQFYZZRF+2dLHsWE4YvJA=="
     },
     "use-sidecar": {
       "version": "1.0.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "build": "gatsby build --prefix-paths"
   },
   "dependencies": {
-    "@primer/components": "^16.1.0",
+    "@primer/components": "^19.0.0",
     "@primer/gatsby-theme-doctocat": "^0.20.1",
     "blob-stream": "^0.1.3",
     "copy-to-clipboard": "^3.3.1",

--- a/docs/src/components/icon.js
+++ b/docs/src/components/icon.js
@@ -9,6 +9,10 @@ export default function Icon({width, height, path, ...props}) {
       fill="currentColor"
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{__html: path}}
+      style={{
+        display: 'inline-block',
+        verticalAlign: 'text-bottom'
+      }}
       {...props}
     />
   )

--- a/docs/src/components/ui-examples-16.js
+++ b/docs/src/components/ui-examples-16.js
@@ -1,0 +1,80 @@
+import {
+  BorderBox,
+  Button,
+  ButtonDanger,
+  ButtonOutline,
+  ButtonPrimary,
+  Flex,
+  Grid,
+  Text,
+  Timeline,
+  UnderlineNav
+} from '@primer/components'
+import React from 'react'
+
+export default function UIExamples16({icon: Icon}) {
+  return (
+    <BorderBox p={3}>
+      <Grid gridGap={3} sx={{justifyItems: 'start'}}>
+        <Text>
+          <Icon />
+          <Text ml={2} contentEditable>
+            Inline text
+          </Text>
+        </Text>
+        <Text>
+          <Icon />
+          <Text ml={2} fontSize={1} contentEditable>
+            Small inline text
+          </Text>
+        </Text>
+        <Timeline>
+          <Timeline.Item>
+            <Timeline.Badge>
+              <Icon />
+            </Timeline.Badge>
+            <Timeline.Body>
+              <Text color="text.gray.8" contentEditable spellCheck="false">
+                Monalisa created one hot potato
+              </Text>
+            </Timeline.Body>
+          </Timeline.Item>
+        </Timeline>
+        <Flex>
+          <Button mr={2}>
+            <Icon />
+            <Text ml={2} contentEditable>
+              Button
+            </Text>
+          </Button>
+          <ButtonPrimary mr={2}>
+            <Icon />
+            <Text ml={2} contentEditable>
+              Button
+            </Text>
+          </ButtonPrimary>
+          <ButtonDanger mr={2}>
+            <Icon />
+            <Text ml={2} contentEditable>
+              Button
+            </Text>
+          </ButtonDanger>
+          <ButtonOutline mr={2}>
+            <Icon />
+            <Text ml={2} contentEditable>
+              Button
+            </Text>
+          </ButtonOutline>
+        </Flex>
+        <UnderlineNav sx={{width: '100%'}}>
+          <UnderlineNav.Link href="#" selected onClick={event => event.preventDefault()}>
+            <Icon />
+            <Text ml={2} contentEditable>
+              Home
+            </Text>
+          </UnderlineNav.Link>
+        </UnderlineNav>
+      </Grid>
+    </BorderBox>
+  )
+}

--- a/docs/src/components/ui-examples-24.js
+++ b/docs/src/components/ui-examples-24.js
@@ -1,0 +1,14 @@
+import {BorderBox, CircleBadge, Grid} from '@primer/components'
+import React from 'react'
+
+export default function UIExamples24({icon: Icon}) {
+  return (
+    <BorderBox p={3}>
+      <Grid gridGap={3} sx={{justifyItems: 'start'}}>
+        <CircleBadge>
+          <Icon />
+        </CircleBadge>
+      </Grid>
+    </BorderBox>
+  )
+}

--- a/docs/src/templates/icon-page.js
+++ b/docs/src/templates/icon-page.js
@@ -1,4 +1,4 @@
-import {Breadcrumb, Button, Flex, Grid, Heading, Box, TabNav} from '@primer/components'
+import {Box, Breadcrumb, Button, Flex, Grid, Heading, TabNav, Text} from '@primer/components'
 import {Container, Head, Header, Sidebar} from '@primer/gatsby-theme-doctocat'
 import Code from '@primer/gatsby-theme-doctocat/src/components/code'
 import {H2, H3} from '@primer/gatsby-theme-doctocat/src/components/heading'
@@ -12,6 +12,8 @@ import React from 'react'
 import svgToPdf from 'svg-to-pdfkit'
 import Icon from '../components/icon'
 import IconViewer from '../components/icon-viewer'
+import UIExamples16 from '../components/ui-examples-16'
+import UIExamples24 from '../components/ui-examples-24'
 
 export default function IconPage({pageContext}) {
   const icon = {
@@ -104,10 +106,27 @@ export default function IconPage({pageContext}) {
 
           <H3>Jekyll</H3>
           <Code>{`{% octicon ${pageContext.name} height:${icon.height} %}`}</Code>
+
+          <H2>UI examples</H2>
+          <UIExamples
+            size={icon.height}
+            icon={props => <Icon width={icon.width} height={icon.height} path={icon.path} {...props} />}
+          />
         </Container>
       </Flex>
     </Flex>
   )
+}
+
+function UIExamples({size, icon}) {
+  switch (size) {
+    case 16:
+      return <UIExamples16 icon={icon} />
+    case 24:
+      return <UIExamples24 icon={icon} />
+    default:
+      return <Text>No examples available</Text>
+  }
 }
 
 function getSvg(icon) {


### PR DESCRIPTION
This PR adds a `UI examples` section to icon pages that shows the current icon used in common pieces of GitHub UI:

![image](https://user-images.githubusercontent.com/4608155/81601845-6bafc600-9380-11ea-918a-ada960cbfb03.png)

👀 [Preview](https://octicons-git-fork-colebemis-ui-examples.primer.now.sh/octicons/link-16#ui-examples)
