### PR TITLE
Change prefix to octicons-v2

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -5,7 +5,7 @@ module.exports = {
     description: "Your project. GitHub's icons.",
     imageUrl: 'https://user-images.githubusercontent.com/10384315/53922681-2f6d3100-402a-11e9-9719-5d1811c8110a.png'
   },
-  pathPrefix: '/octicons',
+  pathPrefix: '/octicons-v2',
   plugins: [
     {
       resolve: '@primer/gatsby-theme-doctocat',

--- a/now.json
+++ b/now.json
@@ -7,6 +7,6 @@
       "config": {"distDir": "public"}
     }
   ],
-  "rewrites": [{"source": "/octicons(/.*)?", "destination": "/docs$1"}],
+  "rewrites": [{"source": "/octicons-v2(/.*)?", "destination": "/docs$1"}],
   "redirects": [{"source": "/", "destination": "/octicons"}]
 }

--- a/now.json
+++ b/now.json
@@ -8,5 +8,5 @@
     }
   ],
   "rewrites": [{"source": "/octicons-v2(/.*)?", "destination": "/docs$1"}],
-  "redirects": [{"source": "/", "destination": "/octicons"}]
+  "redirects": [{"source": "/", "destination": "/octicons-v2"}]
 }


### PR DESCRIPTION
We need to change the path prefix to make `primer.style/octicons-v2` URL work.