### PR TITLE
Remove "v2" from package names

### DIFF
--- a/.github/actions/build_ruby/entrypoint.sh
+++ b/.github/actions/build_ruby/entrypoint.sh
@@ -22,7 +22,7 @@ cd ./lib/$*
 echo "**************** Copying assets files to build directory ****************"
 cp -R ../build lib/
 
-perl -pi -e "s/\"octicons_v2\", \"[^\"]+\"/\"octicons_v2\", \"${PACKAGE_VERSION}\"/" ./Gemfile ./*.gemspec
+perl -pi -e "s/\"octicons\", \"[^\"]+\"/\"octicons\", \"${PACKAGE_VERSION}\"/" ./Gemfile ./*.gemspec
 
 echo "**************** Installing ****************"
 bundle install

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The octicons node.js library is the main JavaScript library. With [a JavaScript 
 
 ### Request a new icon
 
-To request a new icon, open an issue using the [icon request](https://github.com/primer/octicons-v2/issues/new?assignees=&template=icon-request.md&title=%5BIcon+request%5D) template.
+To request a new icon, open an issue using the [icon request](https://github.com/primer/octicons/issues/new?assignees=&template=icon-request.md&title=%5BIcon+request%5D) template.
 
 ### Adding or updating an icon
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -9,8 +9,4 @@ import {Link as GatsbyLink} from 'gatsby'
 
 export default HeroLayout
 
-<Flash scheme="yellow" mb={4}>
-Octicons v10.0.0 is not released yet. In the meantime, we've created temporary <Link as={GatsbyLink} to="/packages">packages</Link> so you can preview the new icons. If you're looking for the latest stable release of Octicons, go <Link href="https://primer.style/octicons">here</Link>.
-</Flash>
-
 <Icons />

--- a/docs/content/packages/javascript.mdx
+++ b/docs/content/packages/javascript.mdx
@@ -1,33 +1,27 @@
 ---
 title: JavaScript
-status: Experimental 
-source: 'https://github.com/primer/octicons/tree/v2/lib/octicons_node'
+status: Stable 
+source: 'https://github.com/primer/octicons/tree/master/lib/octicons_node'
 ---
 
-import {Flash, Link} from '@primer/components'
-
-[![npm version](https://img.shields.io/npm/v/@primer/octicons-v2/canary.svg)](https://www.npmjs.org/package/@primer/octicons-v2)
-
-<Flash scheme="yellow">
-This is a temporary package containing icons that will be released in Octicons v10.0.0. If you're looking for the latest stable release of Octicons, go <Link href="https://primer.style/octicons/packages/ruby">here</Link>.
-</Flash> 
+[![npm version](https://img.shields.io/npm/v/@primer/octicons.svg)](https://www.npmjs.org/package/@primer/octicons)
 
 ## Install
 
-This package is distributed with [npm][npm]. After [installing npm][install-npm], you can install `@primer/octicons-v2` with this command:
+This package is distributed with [npm][npm]. After [installing npm][install-npm], you can install `@primer/octicons` with this command:
 
 ```shell
-npm install @primer/octicons-v2@canary
+npm install @primer/octicons
 ```
 
 ## Usage
 
-For all the usages, we recommend using the CSS located in [`build/build.css`](https://unpkg.com/@primer/octicons-v2@canary/build/build.css). This is some simple CSS to normalize the icons and inherit colors.
+For all the usages, we recommend using the CSS located in [`build/build.css`](https://unpkg.com/@primer/octicons@canary/build/build.css). This is some simple CSS to normalize the icons and inherit colors.
 
-After installing `@primer/octicons-v2` you can access the icons like this:
+After installing `@primer/octicons` you can access the icons like this:
 
 ```js
-var octicons = require("@primer/octicons-v2")
+var octicons = require("@primer/octicons")
 octicons.alert
 // { keywords: [ 'warning', 'triangle', 'exclamation', 'point' ],
 //   path: '<path d="M8.865 1.52c-.18-.31-.51-.5-.87-.5s-.69.19-.87.5L.275 13.5c-.18.31-.18.69 0 1 .19.31.52.5.87.5h13.7c.36 0 .69-.19.86-.5.17-.31.18-.69.01-1L8.865 1.52zM8.995 13h-2v-2h2v2zm0-3h-2V6h2v4z"/>',

--- a/docs/content/packages/javascript.mdx
+++ b/docs/content/packages/javascript.mdx
@@ -16,7 +16,7 @@ npm install @primer/octicons
 
 ## Usage
 
-For all the usages, we recommend using the CSS located in [`build/build.css`](https://unpkg.com/@primer/octicons@canary/build/build.css). This is some simple CSS to normalize the icons and inherit colors.
+For all the usages, we recommend using the CSS located in [`build/build.css`](https://unpkg.com/@primer/octicons/build/build.css). This is some simple CSS to normalize the icons and inherit colors.
 
 After installing `@primer/octicons` you can access the icons like this:
 

--- a/docs/content/packages/jekyll.mdx
+++ b/docs/content/packages/jekyll.mdx
@@ -1,16 +1,11 @@
 ---
 title: Jekyll
-status: Experimental 
-source: 'https://github.com/primer/octicons/tree/v2/lib/octicons_jekyll'
+status: Stable 
+source: 'https://github.com/primer/octicons/tree/master/lib/octicons_jekyll'
 ---
 
-import {Flash, Link} from '@primer/components'
+[![Gem version](https://img.shields.io/gem/v/jekyll-octicons.svg)](https://rubygems.org/gems/jekyll-octicons)
 
-[![Gem version](https://img.shields.io/gem/v/jekyll-octicons_v2.svg)](https://rubygems.org/gems/jekyll-octicons_v2)
-
-<Flash scheme="yellow" my={3}>
-This is a temporary package containing icons that will be released in Octicons v10.0.0. If you want to use the latest stable release of Octicons, go <Link href="https://primer.style/octicons/packages/jekyll">here</Link>.
-</Flash> 
 
 This jekyll liquid tag is a plugin that will let you easily include svg octicons in your jekyll sites.
 
@@ -19,14 +14,14 @@ This jekyll liquid tag is a plugin that will let you easily include svg octicons
 1. Add this to your `Gemfile`
 
     ```rb
-    gem 'jekyll-octicons_v2'
+    gem 'jekyll-octicons'
     ```
 
 2. Add this to your jekyll `_config.yml`
 
     ```yml
     gems:
-      - jekyll-octicons_v2
+      - jekyll-octicons
     ```
 
 3. Use this tag in your jekyll templates
@@ -35,4 +30,4 @@ This jekyll liquid tag is a plugin that will let you easily include svg octicons
     {% octicon alert height:32 class:"right left" aria-label:hi %}
     ```
 
-We recommend including the CSS in the [`@primer/octicons-v2`](/packages/javascript) npm module. You can also npm install that package and include `build/build.css` in your styles.
+We recommend including the CSS in the [`@primer/octicons`](/packages/javascript) npm module. You can also npm install that package and include `build/build.css` in your styles.

--- a/docs/content/packages/rails.mdx
+++ b/docs/content/packages/rails.mdx
@@ -1,16 +1,10 @@
 ---
 title: Rails
-status: Experimental
-source: 'https://github.com/primer/octicons/tree/v2/lib/octicons_v2_helper'
+status: Stable
+source: 'https://github.com/primer/octicons/tree/master/lib/octicons_helper'
 ---
 
-import {Flash, Link} from '@primer/components'
-
-[![Gem version](https://img.shields.io/gem/v/octicons_v2_helper.svg)](https://rubygems.org/gems/octicons_v2_helper)
-
-<Flash scheme="yellow" my={3}>
-This is a temporary package containing icons that will be released in Octicons v10.0.0. If you want to use the latest stable release of Octicons, go <Link href="https://primer.style/octicons/packages/rails">here</Link>.
-</Flash>
+[![Gem version](https://img.shields.io/gem/v/octicons_helper.svg)](https://rubygems.org/gems/octicons_helper)
 
 This rails helper lets you easily include svg octicons in your rails apps.
 
@@ -19,13 +13,13 @@ This rails helper lets you easily include svg octicons in your rails apps.
 1. Add this to your `Gemfile`
 
     ```rb
-    gem 'octicons_v2_helper'
+    gem 'octicons_helper'
     ```
 
 3. Use this tag in your erbs
 
     ```rb
-    <%= octicon_v2 "alert", :height => 32,  :class => "right left", :"aria-label" => "hi" %>
+    <%= octicon "alert", :height => 32,  :class => "right left", :"aria-label" => "hi" %>
     ```
 
-We recommend including the CSS in the [`@primer/octicons-v2`](/packages/javascript) npm module. You can also npm install that package and include `build/build.css` in your styles.
+We recommend including the CSS in the [`@primer/octicons`](/packages/javascript) npm module. You can also npm install that package and include `build/build.css` in your styles.

--- a/docs/content/packages/react.mdx
+++ b/docs/content/packages/react.mdx
@@ -1,34 +1,28 @@
 ---
 title: React
-status: Experimental 
-source: 'https://github.com/primer/octicons/tree/v2/lib/octicons_react'
+status: Stable 
+source: 'https://github.com/primer/octicons/tree/master/lib/octicons_react'
 ---
 
-import {Flash, Link} from '@primer/components'
-
-[![npm version](https://img.shields.io/npm/v/@primer/octicons-v2-react/canary.svg)](https://www.npmjs.org/package/@primer/octicons-v2-react)
-
-<Flash scheme="yellow" my={3}>
-This is a temporary package containing icons that will be released in Octicons v10.0.0. If you want to use the latest stable release of Octicons, go <Link href="https://primer.style/octicons/packages/react">here</Link>.
-</Flash> 
+[![npm version](https://img.shields.io/npm/v/@primer/octicons-react.svg)](https://www.npmjs.org/package/@primer/octicons-react)
 
 ## Install
 
 ```shell
-npm install @primer/octicons-v2-react@canary
+npm install @primer/octicons-react
 ```
 
 ## Usage
 
 ### Icons
-The `@primer/octicons-v2-react` module exports individual icons as [named
+The `@primer/octicons-react` module exports individual icons as [named
 exports](https://ponyfoo.com/articles/es6-modules-in-depth#named-exports). This
 allows you to import only the icons that you need without blowing up your
 bundle:
 
 ```jsx
 import React from 'react'
-import {BeakerIcon, ZapIcon} from '@primer/octicons-v2-react'
+import {BeakerIcon, ZapIcon} from '@primer/octicons-react'
 
 export default function Icon({boom}) {
   return boom ? <ZapIcon /> : <BeakerIcon />
@@ -45,7 +39,7 @@ styles. You can change the alignment via the `verticalAlign` prop, which can be
 either `middle`, `text-bottom`, `text-top`, or `top`.
 
 ```js
-import {RepoIcon} from '@primer/octicons-v2-react'
+import {RepoIcon} from '@primer/octicons-react'
 
 export default () => (
   <h1>
@@ -61,7 +55,7 @@ You have the option of adding accessibility information to the icon with the
 
 ```js
 // Example usage
-import {PlusIcon} from '@primer/octicons-v2-react'
+import {PlusIcon} from '@primer/octicons-react'
 
 export default () => (
   <button>
@@ -83,7 +77,7 @@ render octicons at standard sizes:
 
 ```js
 // Example usage
-import {LogoGithubIcon} from '@primer/octicons-v2-react'
+import {LogoGithubIcon} from '@primer/octicons-react'
 
 export default () => (
   <h1>

--- a/docs/content/packages/ruby.mdx
+++ b/docs/content/packages/ruby.mdx
@@ -1,23 +1,17 @@
 ---
 title: Ruby
-status: Experimental
-source: 'https://github.com/primer/octicons/tree/v2/lib/octicons_gem'
+status: Stable
+source: 'https://github.com/primer/octicons/tree/master/lib/octicons_gem'
 ---
 
-import {Flash, Link} from '@primer/components'
-
-[![Gem version](https://img.shields.io/gem/v/octicons_v2.svg)](https://rubygems.org/gems/octicons_v2)
-
-<Flash scheme="yellow" my={3}>
-This is a temporary package containing icons that will be released in Octicons v10.0.0. If you want to use the latest stable release of Octicons, go <Link href="https://primer.style/octicons/packages/ruby">here</Link>.
-</Flash> 
+[![Gem version](https://img.shields.io/gem/v/octicons.svg)](https://rubygems.org/gems/octicons)
 
 ## Install
 
 Add this to your `Gemfile`
 
 ```rb
-gem 'octicons_v2'
+gem 'octicons'
 ```
 
 Then `bundle install`.
@@ -25,15 +19,15 @@ Then `bundle install`.
 ## Usage
 
 ```rb
-require 'octicons_v2'
-icon = OcticonsV2::OcticonV2.new("x")
+require 'octicons'
+icon = Octicons::Octicon.new("x")
 icon.to_svg
 # <svg class="octicon octicon-x" viewBox="0 0 16 16" width="16" height="16" version="1.1" "aria-hidden"="true"><path d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"></path></svg>
 ```
 
 ## Documentation
 
-The `OcticonV2` class takes two arguments. The first is the symbol of the icon, and the second is a hash of arguments representing html attributes
+The `Octicon` class takes two arguments. The first is the symbol of the icon, and the second is a hash of arguments representing html attributes
 
 ### `symbol` _(required)_
 
@@ -55,7 +49,7 @@ Once initialized, you can read a few properties from the icon.
 Returns the string of the symbol name
 
 ```rb
-icon = OcticonsV2::OcticonV2.new("x")
+icon = Octicons::Octicon.new("x")
 icon.symbol
 # "x"
 ```
@@ -65,7 +59,7 @@ icon.symbol
 Path returns the string representation of the path of the icon.
 
 ```rb
-icon = OcticonsV2::OcticonV2.new("x")
+icon = Octicons::Octicon.new("x")
 icon.path
 # <path d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"></path>
 ```
@@ -75,7 +69,7 @@ icon.path
 This is a hash of all the `options` that will be added to the output tag.
 
 ```rb
-icon = OcticonsV2::OcticonV2.new("x")
+icon = Octicons::Octicon.new("x")
 icon.options
 # {:class=>"octicon octicon-x", :viewBox=>"0 0 12 16", :version=>"1.1", :width=>12, :height=>16, :"aria-hidden"=>"true"}
 ```
@@ -93,7 +87,7 @@ Height is the icon's true height. Based on the svg view box height. _Note, this 
 Returns an array of keywords for the icon. The data comes from the [data file in lib](../data.json). Consider contributing more aliases for the icons.
 
 ```rb
-icon = OcticonsV2::OcticonV2.new("x")
+icon = Octicons::Octicon.new("x")
 icon.keywords
 # ["remove", "close", "delete"]
 ```
@@ -105,7 +99,7 @@ icon.keywords
 Returns a string of the svg tag
 
 ```rb
-icon = OcticonsV2::OcticonV2.new("x")
+icon = Octicons::Octicon.new("x")
 icon.to_svg
 # <svg class="octicon octicon-x" viewBox="0 0 16 16" width="16" height="16" version="1.1" "aria-hidden"="true"><path d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"></path></svg>
 ```

--- a/docs/content/packages/styled-system.mdx
+++ b/docs/content/packages/styled-system.mdx
@@ -33,7 +33,7 @@ All icon components in `@primer/styled-octicons` get `color` and `space` system 
 
 ## Props
 
-In addition to system props, icon components in `@primer/styled-octicons` accept the same props as components in `@primer/octicons-v2-react`:
+In addition to system props, icon components in `@primer/styled-octicons` accept the same props as components in `@primer/octicons-react`:
 
 | Name | Type | Default | Description |
 | :- | :- | :-: | :- |

--- a/docs/content/packages/styled-system.mdx
+++ b/docs/content/packages/styled-system.mdx
@@ -1,17 +1,17 @@
 ---
 title: Styled System
-status: Experimental 
-source: 'https://github.com/primer/octicons/tree/v2/lib/octicons_styled'
+status: Stable 
+source: 'https://github.com/primer/octicons/tree/master/lib/octicons_styled'
 ---
 
-[![npm version](https://img.shields.io/npm/v/@primer/styled-octicons/canary.svg)](https://www.npmjs.org/package/@primer/styled-octicons)
+[![npm version](https://img.shields.io/npm/v/@primer/styled-octicons.svg)](https://www.npmjs.org/package/@primer/styled-octicons)
 
-The `@primer/styled-octicons` package wraps icon components from [`@primer/octicons-v2-react`](/packages/react) with [system props](https://primer.style/components/system-props), making them easier to style in projects that use [styled system](https://styled-system.com/)—like [Primer Components](https://primer.style/components).
+The `@primer/styled-octicons` package wraps icon components from [`@primer/octicons-react`](/packages/react) with [system props](https://primer.style/components/system-props), making them easier to style in projects that use [styled system](https://styled-system.com/)—like [Primer Components](https://primer.style/components).
 
 ## Install
 
 ```shell
-npm install @primer/styled-octicons@canary
+npm install @primer/styled-octicons
 ```
 
 ## Usage

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -5,7 +5,7 @@ module.exports = {
     description: "Your project. GitHub's icons.",
     imageUrl: 'https://user-images.githubusercontent.com/10384315/53922681-2f6d3100-402a-11e9-9719-5d1811c8110a.png'
   },
-  pathPrefix: '/octicons-v2',
+  pathPrefix: '/octicons',
   plugins: [
     {
       resolve: '@primer/gatsby-theme-doctocat',

--- a/lib/octicons_gem/Rakefile
+++ b/lib/octicons_gem/Rakefile
@@ -12,10 +12,10 @@ Rake::TestTask.new do |t|
 end
 
 task :version, [:v] do |t, args|
-  out = "module OcticonsV2\n"\
+  out = "module Octicons\n"\
     "  VERSION = \"#{args[:v]}\".freeze\n"\
     "end"
-  File.open(File.expand_path("../lib/octicons_v2/version.rb", __FILE__), "w") { |file| file.puts out }
+  File.open(File.expand_path("../lib/octicons/version.rb", __FILE__), "w") { |file| file.puts out }
 end
 
 desc "Run tests"

--- a/lib/octicons_gem/lib/octicons.rb
+++ b/lib/octicons_gem/lib/octicons.rb
@@ -1,8 +1,8 @@
-require "octicons_v2/version"
-require "octicons_v2/octicon_v2"
+require "octicons/version"
+require "octicons/octicon"
 require "json"
 
-module OcticonsV2
+module Octicons
   file_data = File.read(File.join(File.dirname(__FILE__), "./build/data.json"))
   OCTICON_SYMBOLS = JSON.parse(file_data).freeze
 end

--- a/lib/octicons_gem/lib/octicons/octicon.rb
+++ b/lib/octicons_gem/lib/octicons/octicon.rb
@@ -1,5 +1,5 @@
-module OcticonsV2
-  class OcticonV2
+module Octicons
+  class Octicon
     DEFAULT_HEIGHT = 16
 
     attr_reader :path, :options, :width, :height, :symbol, :keywords
@@ -84,7 +84,7 @@ module OcticonsV2
     end
 
     def get_octicon(symbol, options = {})
-      if octicon = OcticonsV2::OCTICON_SYMBOLS[symbol]
+      if octicon = Octicons::OCTICON_SYMBOLS[symbol]
         # We're using width as an approximation for height if the height option is not passed in
         height = options[:height] || options[:width] || DEFAULT_HEIGHT
         natural_height = closest_natural_height(octicon["heights"].keys, height)

--- a/lib/octicons_gem/lib/octicons/version.rb
+++ b/lib/octicons_gem/lib/octicons/version.rb
@@ -1,3 +1,3 @@
-module OcticonsV2Helper
+module Octicons
   VERSION = "10.0.0".freeze
 end

--- a/lib/octicons_gem/octicons.gemspec
+++ b/lib/octicons_gem/octicons.gemspec
@@ -1,8 +1,8 @@
-require File.expand_path("../lib/octicons_v2/version", __FILE__)
+require File.expand_path("../lib/octicons/version", __FILE__)
 
 Gem::Specification.new do |s|
-  s.name        = "octicons_v2"
-  s.version     = OcticonsV2::VERSION
+  s.name        = "octicons"
+  s.version     = Octicons::VERSION
   s.summary     = "GitHub's octicons gem"
   s.platform    = Gem::Platform::RUBY
   s.description = "A package that distributes Octicons in a gem"

--- a/lib/octicons_gem/test/helper.rb
+++ b/lib/octicons_gem/test/helper.rb
@@ -1,6 +1,6 @@
 require "minitest/autorun"
-require "octicons_v2"
+require "octicons"
 
-def octicon_v2(symbol, options = {})
-  ::OcticonsV2::OcticonV2.new(symbol, options)
+def octicon(symbol, options = {})
+  ::Octicons::Octicon.new(symbol, options)
 end

--- a/lib/octicons_gem/test/octicon_test.rb
+++ b/lib/octicons_gem/test/octicon_test.rb
@@ -1,29 +1,29 @@
 require_relative "./helper"
 
-describe OcticonsV2::OcticonV2 do
+describe Octicons::Octicon do
   it "fails when the octicon doesn't exist" do
     assert_raises(RuntimeError) do
-      octicon_v2("octicon")
+      octicon("octicon")
     end
   end
 
   it "initialize accepts a string for an icon" do
-    icon = octicon_v2("x")
+    icon = octicon("x")
     assert icon
   end
 
   it "initialize accepts a symbol for an icon" do
-    icon = octicon_v2(:x)
+    icon = octicon(:x)
     assert icon
   end
 
   it "gets keywords for the icon" do
-    icon = octicon_v2("mark-github")
+    icon = octicon("mark-github")
     assert_equal ["octocat", "brand", "github", "logo"], icon.keywords
   end
 
   it "the attributes are readable" do
-    icon = octicon_v2("x")
+    icon = octicon("x")
     assert icon.path
     assert icon.options
     assert_equal "x", icon.symbol
@@ -33,14 +33,14 @@ describe OcticonsV2::OcticonV2 do
 
   describe "viewBox" do
     it "always has a viewBox" do
-      icon = octicon_v2("x")
+      icon = octicon("x")
       assert_includes icon.to_svg, "viewBox=\"0 0 16 16\""
     end
   end
 
   describe "html_attributes" do
     it "includes other html attributes" do
-      icon = octicon_v2("x", foo: "bar", disabled: "true")
+      icon = octicon("x", foo: "bar", disabled: "true")
       assert_includes icon.to_svg, "disabled=\"true\""
       assert_includes icon.to_svg, "foo=\"bar\""
     end
@@ -48,64 +48,64 @@ describe OcticonsV2::OcticonV2 do
 
   describe "classes" do
     it "includes classes passed in" do
-      icon = octicon_v2("x", class: "text-closed")
+      icon = octicon("x", class: "text-closed")
       assert_includes icon.to_svg, "class=\"octicon octicon-x text-closed\""
     end
   end
 
   describe "size" do
     it "always has width and height" do
-      icon = octicon_v2("x")
+      icon = octicon("x")
       assert_includes icon.to_svg, "height=\"16\""
       assert_includes icon.to_svg, "width=\"16\""
     end
 
     it "converts number string height to integer" do
-      icon = octicon_v2("x", height: "60")
+      icon = octicon("x", height: "60")
       assert_includes icon.to_svg, "height=\"60\""
       assert_includes icon.to_svg, "width=\"60\""
     end
 
     it "converts number height to integer" do
-      icon = octicon_v2("x", height: 60)
+      icon = octicon("x", height: 60)
       assert_includes icon.to_svg, "height=\"60\""
       assert_includes icon.to_svg, "width=\"60\""
     end
 
     it "converts number string width to integer" do
-      icon = octicon_v2("x", width: "45")
+      icon = octicon("x", width: "45")
       assert_includes icon.to_svg, "height=\"45\""
       assert_includes icon.to_svg, "width=\"45\""
     end
 
     it "converts number width to integer" do
-      icon = octicon_v2("x", width: 45)
+      icon = octicon("x", width: 45)
       assert_includes icon.to_svg, "height=\"45\""
       assert_includes icon.to_svg, "width=\"45\""
     end
 
     it "with height and width passed in" do
-      icon = octicon_v2("x", width: 60, height: 60)
+      icon = octicon("x", width: 60, height: 60)
       assert_includes icon.to_svg, "width=\"60\""
       assert_includes icon.to_svg, "height=\"60\""
     end
 
     it "chooses the correct svg given a height" do
-      icon = octicon_v2("x", height: 32)
+      icon = octicon("x", height: 32)
       assert_includes icon.to_svg, "width=\"32\""
       assert_includes icon.to_svg, "height=\"32\""
       assert_includes icon.to_svg, "viewBox=\"0 0 24 24\""
     end
 
     it "chooses the correct svg given a width" do
-      icon = octicon_v2("x", width: 24)
+      icon = octicon("x", width: 24)
       assert_includes icon.to_svg, "width=\"24\""
       assert_includes icon.to_svg, "height=\"24\""
       assert_includes icon.to_svg, "viewBox=\"0 0 24 24\""
     end
 
     it "chooses the correct svg given a height and width" do
-      icon = octicon_v2("x", height: 24, width: 16)
+      icon = octicon("x", height: 24, width: 16)
       assert_includes icon.to_svg, "width=\"16\""
       assert_includes icon.to_svg, "height=\"24\""
       assert_includes icon.to_svg, "viewBox=\"0 0 24 24\""
@@ -114,21 +114,21 @@ describe OcticonsV2::OcticonV2 do
 
   describe "a11y" do
     it "includes attributes for symbol keys" do
-      icon = octicon_v2("x", "aria-label": "Close")
+      icon = octicon("x", "aria-label": "Close")
       assert_includes icon.to_svg, "role=\"img\""
       assert_includes icon.to_svg, "aria-label=\"Close\""
       refute_includes icon.to_svg, "aria-hidden"
     end
 
     it "includes attributes for string keys" do
-      icon = octicon_v2("x", "aria-label" => "Close")
+      icon = octicon("x", "aria-label" => "Close")
       assert_includes icon.to_svg, "role=\"img\""
       assert_includes icon.to_svg, "aria-label=\"Close\""
       refute_includes icon.to_svg, "aria-hidden"
     end
 
     it "has aria-hidden when no label is passed in" do
-      icon = octicon_v2("x")
+      icon = octicon("x")
       assert_includes icon.to_svg, "aria-hidden=\"true\""
     end
   end

--- a/lib/octicons_gem/test/octicons_test.rb
+++ b/lib/octicons_gem/test/octicons_test.rb
@@ -1,9 +1,9 @@
 require_relative "./helper"
 
-describe OcticonsV2 do
+describe Octicons do
   it "loads all icons on initialization" do
-    refute_equal 0, OcticonsV2::OCTICON_SYMBOLS.length
-    x_icon = OcticonsV2::OCTICON_SYMBOLS["x"]
+    refute_equal 0, Octicons::OCTICON_SYMBOLS.length
+    x_icon = Octicons::OCTICON_SYMBOLS["x"]
     assert x_icon["name"]
     assert x_icon["keywords"]
     assert x_icon["heights"]

--- a/lib/octicons_helper/Gemfile
+++ b/lib/octicons_helper/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "octicons_v2", "10.0.0"
+gem "octicons", "10.0.0"
 gem "rails"
 
 group :development, :test do

--- a/lib/octicons_helper/Rakefile
+++ b/lib/octicons_helper/Rakefile
@@ -7,17 +7,17 @@ RuboCop::RakeTask.new(:lint) do |t|
 end
 
 task :version, [:v] do |t, args|
-  out = "module OcticonsV2Helper\n"\
+  out = "module OcticonsHelper\n"\
     "  VERSION = \"#{args[:v]}\".freeze\n"\
     "end"
-  File.open(File.expand_path("../lib/octicons_v2_helper/version.rb", __FILE__), "w") do |file|
+  File.open(File.expand_path("../lib/octicons_helper/version.rb", __FILE__), "w") do |file|
     file.puts out
   end
 
-  ["octicons_v2_helper.gemspec", "Gemfile"].each do |filename|
+  ["octicons_helper.gemspec", "Gemfile"].each do |filename|
     gs = File.read(File.expand_path("../#{filename}", __FILE__))
     File.open(File.expand_path("../#{filename}", __FILE__), "w") do |file|
-      file.puts gs.gsub(/"octicons_v2", "[^"]+"/, "\"octicons_v2\", \"#{args[:v]}\"")
+      file.puts gs.gsub(/"octicons", "[^"]+"/, "\"octicons\", \"#{args[:v]}\"")
     end
   end
 end

--- a/lib/octicons_helper/lib/octicons_helper.rb
+++ b/lib/octicons_helper/lib/octicons_helper.rb
@@ -1,0 +1,3 @@
+require "octicons_helper/version"
+require "octicons_helper/helper"
+require "octicons_helper/railtie" if defined?(Rails)

--- a/lib/octicons_helper/lib/octicons_helper/helper.rb
+++ b/lib/octicons_helper/lib/octicons_helper/helper.rb
@@ -1,14 +1,14 @@
-require "octicons_v2"
+require "octicons"
 require "action_view"
 
-module OcticonsV2Helper
+module OcticonsHelper
 
   include ActionView::Helpers::TagHelper
 
-  def octicon_v2(symbol, options = {})
+  def octicon(symbol, options = {})
     return "" if symbol.nil?
 
-    icon = OcticonsV2::OcticonV2.new(symbol, options)
+    icon = Octicons::Octicon.new(symbol, options)
     content_tag(:svg, icon.path.html_safe, icon.options) # rubocop:disable Rails/OutputSafety
   end
 end

--- a/lib/octicons_helper/lib/octicons_helper/railtie.rb
+++ b/lib/octicons_helper/lib/octicons_helper/railtie.rb
@@ -1,0 +1,9 @@
+require "rails"
+
+module OcticonsHelper
+  class Railtie < Rails::Railtie
+    initializer "octicons_helper.helper" do
+      ActionView::Base.send :include, OcticonsHelper
+    end
+  end
+end

--- a/lib/octicons_helper/lib/octicons_helper/version.rb
+++ b/lib/octicons_helper/lib/octicons_helper/version.rb
@@ -1,3 +1,3 @@
-module OcticonsV2
+module OcticonsHelper
   VERSION = "10.0.0".freeze
 end

--- a/lib/octicons_helper/lib/octicons_v2_helper.rb
+++ b/lib/octicons_helper/lib/octicons_v2_helper.rb
@@ -1,3 +1,0 @@
-require "octicons_v2_helper/version"
-require "octicons_v2_helper/helper"
-require "octicons_v2_helper/railtie" if defined?(Rails)

--- a/lib/octicons_helper/lib/octicons_v2_helper/railtie.rb
+++ b/lib/octicons_helper/lib/octicons_v2_helper/railtie.rb
@@ -1,9 +1,0 @@
-require "rails"
-
-module OcticonsV2Helper
-  class Railtie < Rails::Railtie
-    initializer "octicons_v2_helper.helper" do
-      ActionView::Base.send :include, OcticonsV2Helper
-    end
-  end
-end

--- a/lib/octicons_helper/octicons_helper.gemspec
+++ b/lib/octicons_helper/octicons_helper.gemspec
@@ -1,8 +1,8 @@
-require File.expand_path("../lib/octicons_v2_helper/version", __FILE__)
+require File.expand_path("../lib/octicons_helper/version", __FILE__)
 
 Gem::Specification.new do |s|
-  s.name        = "octicons_v2_helper"
-  s.version     = OcticonsV2Helper::VERSION
+  s.name        = "octicons_helper"
+  s.version     = OcticonsHelper::VERSION
   s.summary     = "Octicons rails helper"
   s.description = "A rails helper that makes including svg Octicons simple."
   s.authors     = ["GitHub Inc."]
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "octicons_v2", "10.0.0"
+  s.add_dependency "octicons", "10.0.0"
   s.add_dependency "rails"
 end

--- a/lib/octicons_helper/test/helper.rb
+++ b/lib/octicons_helper/test/helper.rb
@@ -1,4 +1,4 @@
 require "minitest/autorun"
-require "octicons_v2_helper"
+require "octicons_helper"
 
-include OcticonsV2Helper
+include OcticonsHelper

--- a/lib/octicons_helper/test/octicons_helper_test.rb
+++ b/lib/octicons_helper/test/octicons_helper_test.rb
@@ -1,21 +1,21 @@
 require_relative "./helper"
 
-describe OcticonsV2Helper do
+describe OcticonsHelper do
   describe "rendering" do
     it "renders nothing when no symbol is passed in" do
-      assert_equal "", octicon_v2(nil)
+      assert_equal "", octicon(nil)
     end
 
     it "renders the svg" do
-      assert_match /<svg.*octicon-x.*>.*<\/svg>/, octicon_v2("x")
+      assert_match /<svg.*octicon-x.*>.*<\/svg>/, octicon("x")
     end
 
     it "has a path" do
-      assert_match /<path/, octicon_v2("alert")
+      assert_match /<path/, octicon("alert")
     end
 
     it "adds html attributes to output" do
-      assert_match /foo="bar"/, octicon_v2("alert", foo: "bar")
+      assert_match /foo="bar"/, octicon("alert", foo: "bar")
     end
   end
 end

--- a/lib/octicons_jekyll/Gemfile
+++ b/lib/octicons_jekyll/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "octicons_v2", "10.0.0"
+gem "octicons", "10.0.0"
 
 group :development, :test do
   gem "minitest"

--- a/lib/octicons_jekyll/Rakefile
+++ b/lib/octicons_jekyll/Rakefile
@@ -21,7 +21,7 @@ task :version, [:v] do |t, args|
   ["jekyll-octicons.gemspec", "Gemfile"].each do |filename|
     gs = File.read(File.expand_path("../#{filename}", __FILE__))
     File.open(File.expand_path("../#{filename}", __FILE__), "w") do |file|
-      file.puts gs.gsub(/"octicons_v2", "[^"]+"/, "\"octicons_v2\", \"#{args[:v]}\"")
+      file.puts gs.gsub(/"octicons", "[^"]+"/, "\"octicons\", \"#{args[:v]}\"")
     end
   end
 end

--- a/lib/octicons_jekyll/jekyll-octicons.gemspec
+++ b/lib/octicons_jekyll/jekyll-octicons.gemspec
@@ -1,7 +1,7 @@
 require File.expand_path("../lib/jekyll-octicons/version", __FILE__)
 
 Gem::Specification.new do |s|
-  s.name        = "jekyll-octicons_v2"
+  s.name        = "jekyll-octicons"
   s.version     = Jekyll::Octicons::VERSION
   s.summary     = "Octicons jekyll liquid tag"
   s.description = "A jekyll liquid plugin that makes including svg Octicons simple."
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "jekyll", ">= 3.6", "< 5.0"
-  s.add_dependency "octicons_v2", "10.0.0"
+  s.add_dependency "octicons", "10.0.0"
 end

--- a/lib/octicons_jekyll/lib/jekyll-octicons.rb
+++ b/lib/octicons_jekyll/lib/jekyll-octicons.rb
@@ -1,4 +1,4 @@
-require "octicons_v2"
+require "octicons"
 require "jekyll-octicons/version"
 require "liquid"
 require "jekyll/liquid_extensions"
@@ -31,7 +31,7 @@ module Jekyll
       prepare(interpolate(@markup, context)) if match = @markup.match(Variable)
 
       return nil if @symbol.nil?
-      ::OcticonsV2::OcticonV2.new(@symbol, @options).to_svg
+      ::Octicons::Octicon.new(@symbol, @options).to_svg
     end
 
     private

--- a/lib/octicons_node/package-lock.json
+++ b/lib/octicons_node/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@primer/octicons-v2",
+  "name": "@primer/octicons",
   "version": "10.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/lib/octicons_node/package.json
+++ b/lib/octicons_node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@primer/octicons-v2",
+  "name": "@primer/octicons",
   "version": "10.0.0",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",

--- a/lib/octicons_react/package-lock.json
+++ b/lib/octicons_react/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@primer/octicons-v2-react",
+  "name": "@primer/octicons-react",
   "version": "10.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@primer/octicons-v2-react",
+  "name": "@primer/octicons-react",
   "version": "10.0.0",
   "description": "A scalable set of icons handcrafted with <3 by GitHub.",
   "homepage": "https://octicons.github.com",

--- a/now.json
+++ b/now.json
@@ -7,6 +7,6 @@
       "config": {"distDir": "public"}
     }
   ],
-  "rewrites": [{"source": "/octicons-v2(/.*)?", "destination": "/docs$1"}],
-  "redirects": [{"source": "/", "destination": "/octicons-v2"}]
+  "rewrites": [{"source": "/octicons(/.*)?", "destination": "/docs$1"}],
+  "redirects": [{"source": "/", "destination": "/octicons"}]
 }


### PR DESCRIPTION
This PR removes all references to "v2" in Octicons packages and documentation. Merging this PR into the `v2` branch will allow us to merge the `v2` branch into `master`. 