### PR TITLE
docs: Fix the example for the deprecated Octicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 - The `Octicon` component is deprecated. Use icon components on their own instead:
 
   ```diff
-  - <Octicon icon={AlertIcon} />
+  - <Octicon icon={Alert} />
   + <AlertIcon />
   ```
 

--- a/docs/content/packages/react.mdx
+++ b/docs/content/packages/react.mdx
@@ -92,7 +92,7 @@ export default () => (
 
 > ⚠️ The `Octicon` component is deprecated. Use icon components on their own instead:
 > ```diff
-- <Octicon icon={AlertIcon} />
+- <Octicon icon={Alert} />
 + <AlertIcon />
 ```
 

--- a/lib/octicons_react/src/index.d.ts
+++ b/lib/octicons_react/src/index.d.ts
@@ -14,7 +14,7 @@ export interface OcticonProps {
 }
 
 /**
- * @deprecated Use icon components on their own instead (e.g. `<Octicon icon={AlertIcon} />` → `<AlertIcon />`)
+ * @deprecated Use icon components on their own instead (e.g. `<Octicon icon={Alert} />` → `<AlertIcon />`)
  */
 declare const Octicon: React.FC<OcticonProps>
 

--- a/lib/octicons_react/src/index.js
+++ b/lib/octicons_react/src/index.js
@@ -4,7 +4,7 @@ export default function Octicon({icon: Icon, children, ...props}) {
   // eslint-disable-next-line no-console
   console.warn(
     // eslint-disable-next-line github/unescaped-html-literal
-    '<Octicon> is deprecated. Use icon components on their own instead (e.g. <Octicon icon={AlertIcon} /> → <AlertIcon />)'
+    '<Octicon> is deprecated. Use icon components on their own instead (e.g. <Octicon icon={Alert} /> → <AlertIcon />)'
   )
   return typeof Icon === 'function' ? <Icon {...props} /> : React.cloneElement(React.Children.only(children), props)
 }


### PR DESCRIPTION
The example of the deprecated usage of Octicon component has wrong suffix for the icon name.