### PR TITLE
Adding pull_request to the list of triggers only on main

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,8 @@
-on: push
+on:
+  push:
+  pull_request:
+    branches:
+      - main
 name: Octicons Build
 jobs:
   setup:


### PR DESCRIPTION
This should make the checks run whenever an outside collaborator tries to contribute to opening a PR. Right now it was only running when pushes were made.

cc @colebemis 