### PR TITLE
[React] Add fill prop

### DIFF
--- a/docs/content/packages/react.mdx
+++ b/docs/content/packages/react.mdx
@@ -93,7 +93,7 @@ export default () => (
 ### Fill
 
 The `fill` prop takes a string value that can be used to set the color of the icon.
-By default, `fill` is set to `currentColor`, which means it inherits it's parent's text color.
+By default, `fill` is set to [`currentColor`](https://css-tricks.com/currentcolor/).
 
 ```js
 // Example usage

--- a/docs/content/packages/react.mdx
+++ b/docs/content/packages/react.mdx
@@ -15,6 +15,7 @@ npm install @primer/octicons-react
 ## Usage
 
 ### Icons
+
 The `@primer/octicons-react` module exports individual icons as [named
 exports](https://ponyfoo.com/articles/es6-modules-in-depth#named-exports). This
 allows you to import only the icons that you need without blowing up your
@@ -34,6 +35,7 @@ If you were to compile this example with a tool that supports [tree-shaking][]
 the "zap" and "beaker" icons.
 
 ### Vertical alignment
+
 By default the octicons have `vertical-align: text-bottom;` applied as inline
 styles. You can change the alignment via the `verticalAlign` prop, which can be
 either `middle`, `text-bottom`, `text-top`, or `top`.
@@ -43,13 +45,13 @@ import {RepoIcon} from '@primer/octicons-react'
 
 export default () => (
   <h1>
-    <RepoIcon verticalAlign='middle' /> github/github
+    <RepoIcon verticalAlign="middle" /> github/github
   </h1>
 )
 ```
 
-
 ### `aria-label`
+
 You have the option of adding accessibility information to the icon with the
 [`aria-label` attribute][aria-label] via the `aria-label` prop.
 
@@ -64,16 +66,16 @@ export default () => (
 )
 ```
 
-
 ### Sizes
+
 The `size` prop takes `small`, `medium`, and `large` values that can be used to
 render octicons at standard sizes:
 
-| Prop | Rendered Size |
-| :- | :- |
-| `size='small'` | 16px height by `computed` width |
+| Prop            | Rendered Size                   |
+| :-------------- | :------------------------------ |
+| `size='small'`  | 16px height by `computed` width |
 | `size='medium'` | 32px height by `computed` width |
-| `size='large'` | 64px height by `computed` width |
+| `size='large'`  | 64px height by `computed` width |
 
 ```js
 // Example usage
@@ -81,8 +83,25 @@ import {LogoGithubIcon} from '@primer/octicons-react'
 
 export default () => (
   <h1>
-    <a href='https://github.com'>
-      <LogoGithubIcon size='large' aria-label='GitHub'/>
+    <a href="https://github.com">
+      <LogoGithubIcon size="large" aria-label="GitHub" />
+    </a>
+  </h1>
+)
+```
+
+### Fill
+
+The `fill` prop takes a string value that can be used to set the color of the icon.
+By default, `fill` is set to `currentColor`, which means it inherits it's parent's text color.
+
+```js
+// Example usage
+import {LogoGithub} from '@primer/octicons-react'
+export default () => (
+  <h1>
+    <a href="https://github.com">
+      <LogoGithubIcon fill="#f00" />
     </a>
   </h1>
 )

--- a/lib/octicons_react/package-lock.json
+++ b/lib/octicons_react/package-lock.json
@@ -169,7 +169,7 @@
         "@babel/parser": "^7.8.4",
         "@babel/types": "^7.8.3",
         "debug": "^4.1.0",
-        "globals": "^11.2.0",
+        "globals": "^11.1.0",
         "lodash": "^4.17.13"
       },
       "dependencies": {

--- a/lib/octicons_react/script/build.js
+++ b/lib/octicons_react/script/build.js
@@ -32,7 +32,7 @@ ${name}.defaultProps = {
       key,
       name,
       octicon,
-      code,
+      code
     }
   })
   .sort((a, b) => a.key.localeCompare(b.key))
@@ -88,7 +88,7 @@ fse
   .mkdirs(srcDir)
   .then(() => writeIcons(iconsFile))
   .then(() => writeTypes(typesFile))
-  .catch((error) => {
+  .catch(error => {
     console.error(error)
     process.exit(1)
   })

--- a/lib/octicons_react/script/build.js
+++ b/lib/octicons_react/script/build.js
@@ -32,7 +32,7 @@ ${name}.defaultProps = {
       key,
       name,
       octicon,
-      code
+      code,
     }
   })
   .sort((a, b) => a.key.localeCompare(b.key))
@@ -64,6 +64,7 @@ type Size = 'small' | 'medium' | 'large'
 interface IconProps {
   'aria-label'?: string
   className?: string
+  fill?: string
   size?: number | Size
   verticalAlign?: 'middle' | 'text-bottom' | 'text-top' | 'top' | 'unset'
 }
@@ -87,7 +88,7 @@ fse
   .mkdirs(srcDir)
   .then(() => writeIcons(iconsFile))
   .then(() => writeTypes(typesFile))
-  .catch(error => {
+  .catch((error) => {
     console.error(error)
     process.exit(1)
   })

--- a/lib/octicons_react/src/__tests__/octicon.js
+++ b/lib/octicons_react/src/__tests__/octicon.js
@@ -53,6 +53,11 @@ describe('An icon component', () => {
     expect(container.querySelector('svg')).toHaveAttribute('class', 'foo')
   })
 
+  it('respects the fill prop', () => {
+    const {container} = render(<AlertIcon fill="#f00" />)
+    expect(container.querySelector('svg')).toHaveAttribute('fill', '#f00')
+  })
+
   it('respects the verticalAlign prop', () => {
     const {container} = render(<AlertIcon verticalAlign="middle" />)
     expect(container.querySelector('svg')).toHaveStyle({verticalAlign: 'middle'})

--- a/lib/octicons_react/src/get-svg-props.js
+++ b/lib/octicons_react/src/get-svg-props.js
@@ -1,10 +1,17 @@
 const sizeMap = {
   small: 16,
   medium: 32,
-  large: 64
+  large: 64,
 }
 
-export default function getSvgProps({'aria-label': ariaLabel, className, size, verticalAlign, svgDataByHeight}) {
+export default function getSvgProps({
+  'aria-label': ariaLabel,
+  className,
+  fill = 'currentColor',
+  size,
+  verticalAlign,
+  svgDataByHeight,
+}) {
   const height = sizeMap[size] || size
   const naturalHeight = closestNaturalHeight(Object.keys(svgDataByHeight), height)
   const naturalWidth = svgDataByHeight[naturalHeight].width
@@ -19,18 +26,18 @@ export default function getSvgProps({'aria-label': ariaLabel, className, size, v
     viewBox: `0 0 ${naturalWidth} ${naturalHeight}`,
     width,
     height,
-    fill: 'currentColor',
+    fill,
     style: {
       display: 'inline-block',
       userSelect: 'none',
-      verticalAlign
+      verticalAlign,
     },
-    dangerouslySetInnerHTML: {__html: path}
+    dangerouslySetInnerHTML: {__html: path},
   }
 }
 
 function closestNaturalHeight(naturalHeights, height) {
   return naturalHeights
-    .map(naturalHeight => parseInt(naturalHeight, 10))
+    .map((naturalHeight) => parseInt(naturalHeight, 10))
     .reduce((acc, naturalHeight) => (naturalHeight <= height ? naturalHeight : acc), naturalHeights[0])
 }

--- a/lib/octicons_react/src/get-svg-props.js
+++ b/lib/octicons_react/src/get-svg-props.js
@@ -1,7 +1,7 @@
 const sizeMap = {
   small: 16,
   medium: 32,
-  large: 64,
+  large: 64
 }
 
 export default function getSvgProps({
@@ -10,7 +10,7 @@ export default function getSvgProps({
   fill = 'currentColor',
   size,
   verticalAlign,
-  svgDataByHeight,
+  svgDataByHeight
 }) {
   const height = sizeMap[size] || size
   const naturalHeight = closestNaturalHeight(Object.keys(svgDataByHeight), height)
@@ -30,14 +30,14 @@ export default function getSvgProps({
     style: {
       display: 'inline-block',
       userSelect: 'none',
-      verticalAlign,
+      verticalAlign
     },
-    dangerouslySetInnerHTML: {__html: path},
+    dangerouslySetInnerHTML: {__html: path}
   }
 }
 
 function closestNaturalHeight(naturalHeights, height) {
   return naturalHeights
-    .map((naturalHeight) => parseInt(naturalHeight, 10))
+    .map(naturalHeight => parseInt(naturalHeight, 10))
     .reduce((acc, naturalHeight) => (naturalHeight <= height ? naturalHeight : acc), naturalHeights[0])
 }

--- a/lib/octicons_react/src/index.d.ts
+++ b/lib/octicons_react/src/index.d.ts
@@ -8,6 +8,7 @@ export interface OcticonProps {
   'aria-label'?: string
   children?: React.ReactElement<any>
   className?: string
+  fill?: string
   icon?: Icon
   size?: number | Size
   verticalAlign?: 'middle' | 'text-bottom' | 'text-top' | 'top' | 'unset'


### PR DESCRIPTION
## Problem

Our octicon components don't provide a way to change the `fill` attribute of the underlying SVG.

## Solution

This PR adds a fill prop to all octicon components. @macno originally implemented this in #418 but merge conflicts made that PR difficult to merge.

Co-authored-by: @macno