### PR TITLE
Use more explicit dependencies for Rails helper

### DIFF
--- a/lib/octicons_helper/octicons_helper.gemspec
+++ b/lib/octicons_helper/octicons_helper.gemspec
@@ -14,5 +14,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "octicons", "12.1.0"
-  s.add_dependency "rails"
+  s.add_dependency "railties"
+  s.add_dependency "actionview"
 end


### PR DESCRIPTION
This doesn't require all of Rails, only ActionView & Railties. Reducing the dependencies here means that it enables folks to use only parts of Rails and to slim down their applications by removing unused components of Rails.