### PR TITLE
Prevent clipping using `overflow: visible`

### DIFF
--- a/lib/octicons_node/index.scss
+++ b/lib/octicons_node/index.scss
@@ -2,4 +2,5 @@
   display: inline-block;
   vertical-align: text-top;
   fill: currentColor;
+  overflow: visible;
 }

--- a/lib/octicons_react/src/get-svg-props.js
+++ b/lib/octicons_react/src/get-svg-props.js
@@ -30,7 +30,8 @@ export default function getSvgProps({
     style: {
       display: 'inline-block',
       userSelect: 'none',
-      verticalAlign
+      verticalAlign,
+      overflow: 'visible'
     },
     dangerouslySetInnerHTML: {__html: path}
   }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/12915136/112842600-b78a5d00-906f-11eb-9799-f605ea416348.png)

In Safari, octicons were getting clipped at 85% zoom level The bug is likely a precision problem with Safari. The way Safari rounds the path information of the SVGs when you zoom causes part of the issue icon to be clipped.

This PR works around that bug by allowing SVG paths to overflow their container (`overflow: visible`).