### PR TITLE
Adding symbol files to output of build process

### DIFF
--- a/.github/actions/build_node/entrypoint.sh
+++ b/.github/actions/build_node/entrypoint.sh
@@ -27,9 +27,6 @@ fi
 
 cd ./lib/$*
 
-echo "**************** Copying assets files to build directory ****************"
-cp -R ../build/ .
-
 echo "**************** Installing ****************"
 npm install
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
         uses: ./.github/actions/version
       - run: npm install
       - run: npm run build
-      - run: cp -r icons lib/build/svg
       - uses: actions/upload-artifact@master
         with:
           name: octicons

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "script/version",
     "test": "ava -v tests/*.js",
     "lint": "eslint tests",
-    "build": "script/build.js --input icons/**/*.svg --output lib/build/data.json",
+    "build": "script/build.js --input icons/**/*.svg --output lib/build/data.json && cp -r icons lib/build/svg",
     "start": "cd docs && npm run develop",
     "svgo": "svgo icons --config .svgo.yml"
   },

--- a/script/build.js
+++ b/script/build.js
@@ -97,7 +97,8 @@ const icons = svgFilepaths.map(filepath => {
       keywords: keywords[name] || [],
       width: svgWidth,
       height: svgHeight,
-      path: svgPath
+      path: svgPath,
+      viewBox: svgViewBox
     }
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -126,6 +127,7 @@ const iconsByName = icons.reduce(
         heights: {
           [icon.height]: {
             width: icon.width,
+            viewBox: icon.viewBox,
             path: icon.path
           }
         }
@@ -133,6 +135,18 @@ const iconsByName = icons.reduce(
     }),
   {}
 )
+
+Object.keys(iconsByName).forEach(name => {
+  const icon = iconsByName[name]
+  const {heights} = icon
+  let output = `<svg xmlns="http://www.w3.org/2000/svg"><defs>`
+  Object.keys(heights).forEach(height => {
+    const {width, viewBox, path} = heights[height]
+    output += `<symbol id="octicon-${icon.name}-${height}" viewBox="${viewBox}" width="${width}" height="${height}">${path}</symbol>`
+  })
+  output += `</defs></svg>`
+  fs.outputFileSync(path.resolve(`lib/build/symbols/${icon.name}.svg`), output)
+})
 
 if (argv.output) {
   fs.outputJsonSync(path.resolve(argv.output), iconsByName)

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,6 +5,7 @@ const globby = require('globby')
 const year = new Date().getFullYear()
 const yearRegex = new RegExp(`Copyright \\(c\\) ${year} GitHub Inc\\.`)
 const octiconsLib = fs.readdirSync('./lib/build/svg')
+const octiconsSymbols = fs.readdirSync('./lib/build/symbols')
 const octiconsData = require('../lib/build/data.json')
 
 test(`LICENSE files have the current year ${year}`, t => {
@@ -19,6 +20,10 @@ test(`LICENSE files have the current year ${year}`, t => {
 
 test('SVG icons exist', t => {
   t.not(octiconsLib.length, 0, `We didn't find any svg files`)
+})
+
+test('SVG symbols exist', t => {
+  t.not(octiconsSymbols.length, 0, `We didn't find any symbols files`)
 })
 
 test('Data file exist', t => {


### PR DESCRIPTION
This PR adds to the build script to output [`<symbol>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/symbol) dictionaries for all of the icons. 

I grouped each icon into the `/lib/build/symbols` folder combing each size into one file. So that each icon file eg. `/lib/build/symbols/alert.svg` will contain symbols for ever size namespaced like `id="ocitcon-name-size"`. Here's an example output for `alert.svg`

```xml
<svg xmlns="http://www.w3.org/2000/svg">
  <defs>
    <symbol id="octicon-alert-16" viewBox="0 0 16 16" width="16" height="16">
      <path fill-rule="evenodd" d="M8.22 1.754a.25.25 0 00-.44 0L1.698 13.132a.25.25 0 00.22.368h12.164a.25.25 0 00.22-.368L8.22 1.754zm-1.763-.707c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0114.082 15H1.918a1.75 1.75 0 01-1.543-2.575L6.457 1.047zM9 11a1 1 0 11-2 0 1 1 0 012 0zm-.25-5.25a.75.75 0 00-1.5 0v2.5a.75.75 0 001.5 0v-2.5z"></path>
    </symbol>
    <symbol id="octicon-alert-24" viewBox="0 0 24 24" width="24" height="24">
      <path d="M13 17.5a1 1 0 11-2 0 1 1 0 012 0zm-.25-8.25a.75.75 0 00-1.5 0v4.5a.75.75 0 001.5 0v-4.5z"></path>
      <path fill-rule="evenodd" d="M9.836 3.244c.963-1.665 3.365-1.665 4.328 0l8.967 15.504c.963 1.667-.24 3.752-2.165 3.752H3.034c-1.926 0-3.128-2.085-2.165-3.752L9.836 3.244zm3.03.751a1 1 0 00-1.732 0L2.168 19.499A1 1 0 003.034 21h17.932a1 1 0 00.866-1.5L12.866 3.994z"></path>
    </symbol>
  </defs>
</svg>
```

## Usage

I haven't added any implementation details in this PR yet, but this will allow the libraries to take advantage of these symbols with the `<use ` tag. I would like to build support to either use these files as external assets, this has advantages of being cached as assets by the browser. Example usage:

```html
<svg class="octicon octicon-alert" height="24" viewBox="0 0 24 24" width="24" aria-hidden="true">
  <use href="/node_modules/@primer/octicons/build/symbols/alert.svg#octicon-alert-24"></use>
</svg>
```

I would also like the libraries to allow inlining these symbol dictionaries in the page. This gives us more control over what assets we're serving up and possibility testing new icon symbols to smaller audiences. Example usage: 

```html
<svg class="octicon octicon-alert" height="24" viewBox="0 0 24 24" width="24" aria-hidden="true">
  <use href="#octicon-alert-24"></use>
</svg>
```