### PR TITLE
Change link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To request a new icon, open an issue using the [icon request](https://github.com
 
 ### Adding or updating an icon
 
-Read through our [contributing guide](./.github/CONTRIBUTING.md#adding-or-updating-icons) if you want to add or update icons.
+Read through our [contributing guide](./CONTRIBUTING.md#adding-or-updating-icons) if you want to add or update icons.
 
 ## License
 


### PR DESCRIPTION
Currently, the link for `CONTRIBUTING.md` in the "Adding or updating an icon" section of `README.md` points to a nonexistient file in the `.github` folder. This commit changes that link to point to the correct `CONTRIBUTING.md` in the root directory