### PR TITLE
Fix high CPU usage in docs

### DIFF
--- a/docs/src/templates/icon-page.js
+++ b/docs/src/templates/icon-page.js
@@ -31,7 +31,7 @@ export default function IconPage({pageContext}) {
     () => {
       getPdf(icon).then(blob => setPdf(blob))
     },
-    [icon]
+    [pageContext]
   )
 
   const [copied, setCopied] = React.useState(false)


### PR DESCRIPTION
Noticed high CPU usage from the [icon page](https://primer.style/octicons/star-24) of the Octicon documentation. DevTools confirmed activity, see attached image and trace. Tracked it down to `IconPage` being constantly rerendered. Caused by passing an object created in the component as a dependency to `React.useEffect`, which uses shallow compare by default, causing the hook callback to be executed on every render. Since the callback calls `setPdf`, triggering a render, this causes an infinite loop.

Fixed by using `pageContext` as a dependency instead, which is what the local object is created from. Other solutions exist, e.g. only creating the PDF when the download button is clicked.

<img width="1044" alt="DevTools trace with high CPU" src="https://user-images.githubusercontent.com/7433263/128611286-ec19d640-f0b6-4e9b-b61c-57fbecf78302.png">

[DevTools Trace](https://github.com/primer/octicons/files/6949614/high-cpu-octicons.json.zip). Load in Performance tab of Chrome DevTools to view.
