### PR TITLE
Fix incorrect jekyll-octicons install instructions

### DIFF
--- a/docs/content/packages/jekyll.mdx
+++ b/docs/content/packages/jekyll.mdx
@@ -20,7 +20,7 @@ The Jekyll liquid tag is a plugin that lets you include octicons in your Jekyll 
 2. Add this to your jekyll `_config.yml`
 
     ```yml
-    gems:
+    plugins:
       - jekyll-octicons
     ```
 


### PR DESCRIPTION
Following the instructions I kept getting a `Unknown tag 'octicon'` error on build. Then I finally checked the [jekyll plugin documentation](https://jekyllrb.com/docs/plugins/installation/) and it noted that you have to list your plugins under `plugins` in `_config.yml`, not `gems`.