### PR TITLE
Fix changelog attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@
 
 ### Minor Changes
 
-- [#724](https://github.com/primer/octicons/pull/724) [`855cb27`](https://github.com/primer/octicons/commit/855cb27b7ebd0d728cc85eb1398e94af0a592504) Thanks [@rezrah](https://github.com/rezrah)! - Adding new icons for accessibility, apps, id-badge, log, repo-deleted, tab-external, webhook
+- [#715](https://github.com/primer/octicons/pull/715) [`ab991ab`](https://github.com/primer/octicons/commit/ab991ab318488efc3c02b747168a34e356fad059) Thanks [@edokoa](https://github.com/edokoa)! - Added new icons for:
+- `accessibility`
+- `apps`
+- `id-badge`
+- `log`
+- `repo-deleted`
+- `tab-external`
+- `webhook`
 
 * [#708](https://github.com/primer/octicons/pull/708) [`6933ac3`](https://github.com/primer/octicons/commit/6933ac32f87a2cb5efda4fb74b39d1e6199134ce) Thanks [@Juliusschaeper](https://github.com/Juliusschaeper)! - Added first batch of 16px feed icons:
   - `feed-discussion`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 ### Minor Changes
 
 - [#715](https://github.com/primer/octicons/pull/715) [`ab991ab`](https://github.com/primer/octicons/commit/ab991ab318488efc3c02b747168a34e356fad059) Thanks [@edokoa](https://github.com/edokoa)! - Added new icons for:
-- `accessibility`
-- `apps`
-- `id-badge`
-- `log`
-- `repo-deleted`
-- `tab-external`
-- `webhook`
+  - `accessibility`
+  - `apps`
+  - `id-badge`
+  - `log`
+  - `repo-deleted`
+  - `tab-external`
+  - `webhook`
 
 * [#708](https://github.com/primer/octicons/pull/708) [`6933ac3`](https://github.com/primer/octicons/commit/6933ac32f87a2cb5efda4fb74b39d1e6199134ce) Thanks [@Juliusschaeper](https://github.com/Juliusschaeper)! - Added first batch of 16px feed icons:
   - `feed-discussion`


### PR DESCRIPTION
Fixes attribution on the Changelog to correct user.

This happened because the original PR didn't include a changeset, and the attribution applied to the user (me) that generated the changeset instead.

This fixes this for historical accuracy.

After:
![Screenshot 2022-01-26 at 15 58 27](https://user-images.githubusercontent.com/13340707/151198925-e95b203a-3863-45ae-b75e-47f6f4355902.png)
