### PR TITLE
Update documentation deployment workflows

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -1,4 +1,4 @@
-name: Deploy preview
+name: Deploy
 on:
   pull_request:
 
@@ -10,8 +10,9 @@ permissions:
 jobs:
   deploy:
     if: ${{ github.repository == 'primer/octicons' }}
-    name: Build and deploy
-    uses: primer/.github/.github/workflows/deploy_preview.yml@main
+    name: Preview
+    # SHA for security hardening. Points at last verified HEAD of main branch.
+    uses: primer/.github/.github/workflows/deploy_preview.yml@0cec9b9914f358846163f2428663b58da41028c9
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,4 +1,4 @@
-name: Deploy to production
+name: Deploy
 
 on:
   push:
@@ -18,8 +18,9 @@ permissions:
 
 jobs:
   build_deploy:
-    name: Build and deploy
-    uses: primer/.github/.github/workflows/deploy.yml@main
+    name: Production
+    # Uses SHA for security hardening. Points at last verified HEAD of main branch.
+    uses: primer/.github/.github/workflows/deploy.yml@0cec9b9914f358846163f2428663b58da41028c9
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:


### PR DESCRIPTION
Minor update to the documentation deployment infra, which was recently updated to use the latest Pages GA preview workflows.

This repo already uses the org workflow. The change here switches to using SHA rather than HEAD of `main`. This is for security hardening and leaves deployments less vulnerable to a compromised workflow upstream.

Also fixing the broken workflow on the main branch, that appears on the repo home. Needs this PR to land first.
![broken workflow on repo home](https://user-images.githubusercontent.com/13340707/192557658-0a8f0415-8ebd-481e-a739-37692217213d.png)



## Reviewers

- [ ] Please check the current preview deployment works ([url](https://primer-244619daa0-26589863.drafts.github.io/))

