### PR TITLE
Add `tabIndex` prop to React `Icon` component

### DIFF
--- a/.changeset/sixty-nails-juggle.md
+++ b/.changeset/sixty-nails-juggle.md
@@ -2,4 +2,4 @@
 '@primer/octicons': minor
 ---
 
-Add tabIndex prop to react icons
+Add `tabIndex` prop to React icon components

--- a/.changeset/sixty-nails-juggle.md
+++ b/.changeset/sixty-nails-juggle.md
@@ -1,0 +1,5 @@
+---
+'@primer/octicons': minor
+---
+
+Add focusable prop to react icons

--- a/.changeset/sixty-nails-juggle.md
+++ b/.changeset/sixty-nails-juggle.md
@@ -2,4 +2,4 @@
 '@primer/octicons': minor
 ---
 
-Add focusable prop to react icons
+Add tabIndex prop to react icons

--- a/docs/content/packages/react.mdx
+++ b/docs/content/packages/react.mdx
@@ -66,20 +66,24 @@ export default () => (
 )
 ```
 
-### `focusable`
+### `tabIndex`
 
-You can add the `focusable` attribute to the SVG element via the `focusable` prop, which can be either `true`, `false`, or `auto`.
-If there is no `aria-label` prop presents, `focusable` prop will be set to false and this helps prevent the decorative
-SVG from being announced by some specialized assistive technology browsing modes which get delayed while trying to parse SVG's markup
+You can add the `tabindex` attribute to an SVG element via the `tabIndex` prop if the SVG element is intended to be interactive.
+`tabIndex` prop also controls the `focusable` attribute of the SVG element which is defined by SVG Tiny 1.2 and only implemented in
+Internet Explorer and Microsoft Edge.
+
+If there is no `tabIndex` prop is present (default behaviour), it will set `focusable` attribute to `false` and this is particularly helpful
+for preventing the decorative SVG from being announced by some specialized assistive technology browsing modes which can get delayed
+while trying to parse the SVG markup.
 
 ```js
 // Example usage
 import {PlusIcon} from '@primer/octicons-react'
 
 export default () => (
-  <button>
-    <PlusIcon aria-label="Add new item" focusable="auto" /> New
-  </button>
+
+  <PlusIcon aria-label="Interactive Plus Icon" tabIndex={0} /> New Item
+
 )
 ```
 

--- a/docs/content/packages/react.mdx
+++ b/docs/content/packages/react.mdx
@@ -79,11 +79,8 @@ while trying to parse the SVG markup.
 ```js
 // Example usage
 import {PlusIcon} from '@primer/octicons-react'
-
 export default () => (
-
   <PlusIcon aria-label="Interactive Plus Icon" tabIndex={0} /> New Item
-
 )
 ```
 
@@ -131,16 +128,10 @@ export default () => (
 ### `Octicon` (DEPRECATED)
 
 > ⚠️ The `Octicon` component is deprecated. Use icon components on their own instead:
->
 > ```diff
->
-> ```
-
 - <Octicon icon={AlertIcon} />
-
-* <AlertIcon />
-
-````
++ <AlertIcon />
+```
 
 The `Octicon` component is wrapper that passes props to its icon component. To render a specific icon, you
 can pass it either via the `icon` prop, or as the only child:
@@ -148,7 +139,7 @@ can pass it either via the `icon` prop, or as the only child:
 ```jsx
 <Octicon icon={Icon} />
 <Octicon><Icon x={10}/></Octicon>
-````
+```
 
 [octicons]: https://primer.style/octicons/
 [primer]: https://github.com/primer/primer

--- a/docs/content/packages/react.mdx
+++ b/docs/content/packages/react.mdx
@@ -72,7 +72,7 @@ You can add the `tabindex` attribute to an SVG element via the `tabIndex` prop i
 `tabIndex` prop also controls the `focusable` attribute of the SVG element which is defined by SVG Tiny 1.2 and only implemented in
 Internet Explorer and Microsoft Edge.
 
-If there is no `tabIndex` prop is present (default behaviour), it will set `focusable` attribute to `false` and this is particularly helpful
+If there is no `tabIndex` prop is present (default behavior), it will set the `focusable` attribute to `false`. This is helpful
 for preventing the decorative SVG from being announced by some specialized assistive technology browsing modes which can get delayed
 while trying to parse the SVG markup.
 

--- a/docs/content/packages/react.mdx
+++ b/docs/content/packages/react.mdx
@@ -66,6 +66,23 @@ export default () => (
 )
 ```
 
+### `focusable`
+
+You can add the `focusable` attribute to the SVG element via the `focusable` prop, which can be either `true`, `false`, or `auto`.
+If there is no `aria-label` prop presents, `focusable` prop will be set to false and this helps prevent the decorative
+SVG from being announced by some specialized assistive technology browsing modes which get delayed while trying to parse SVG's markup
+
+```js
+// Example usage
+import {PlusIcon} from '@primer/octicons-react'
+
+export default () => (
+  <button>
+    <PlusIcon aria-label="Add new item" focusable="auto" /> New
+  </button>
+)
+```
+
 ### Sizes
 
 The `size` prop takes `small`, `medium`, and `large` values that can be used to
@@ -110,10 +127,16 @@ export default () => (
 ### `Octicon` (DEPRECATED)
 
 > ⚠️ The `Octicon` component is deprecated. Use icon components on their own instead:
+>
 > ```diff
+>
+> ```
+
 - <Octicon icon={AlertIcon} />
-+ <AlertIcon />
-```
+
+* <AlertIcon />
+
+````
 
 The `Octicon` component is wrapper that passes props to its icon component. To render a specific icon, you
 can pass it either via the `icon` prop, or as the only child:
@@ -121,7 +144,7 @@ can pass it either via the `icon` prop, or as the only child:
 ```jsx
 <Octicon icon={Icon} />
 <Octicon><Icon x={10}/></Octicon>
-```
+````
 
 [octicons]: https://primer.style/octicons/
 [primer]: https://github.com/primer/primer

--- a/lib/octicons_react/__tests__/tree-shaking.test.js
+++ b/lib/octicons_react/__tests__/tree-shaking.test.js
@@ -50,5 +50,5 @@ test('tree shaking single export', async () => {
   })
 
   const bundleSize = Buffer.byteLength(output[0].code.trim()) / 1000
-  expect(`${bundleSize}kB`).toMatchInlineSnapshot(`"2.645kB"`)
+  expect(`${bundleSize}kB`).toMatchInlineSnapshot(`"2.595kB"`)
 })

--- a/lib/octicons_react/__tests__/tree-shaking.test.js
+++ b/lib/octicons_react/__tests__/tree-shaking.test.js
@@ -50,5 +50,5 @@ test('tree shaking single export', async () => {
   })
 
   const bundleSize = Buffer.byteLength(output[0].code.trim()) / 1000
-  expect(`${bundleSize}kB`).toMatchInlineSnapshot(`"2.484kB"`)
+  expect(`${bundleSize}kB`).toMatchInlineSnapshot(`"2.645kB"`)
 })

--- a/lib/octicons_react/src/__tests__/__snapshots__/octicon.js.snap
+++ b/lib/octicons_react/src/__tests__/__snapshots__/octicon.js.snap
@@ -5,6 +5,7 @@ exports[`An icon component matches snapshot 1`] = `
   aria-hidden="true"
   class="octicon octicon-alert"
   fill="currentColor"
+  focusable="false"
   height="16"
   role="img"
   style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"

--- a/lib/octicons_react/src/__tests__/octicon.js
+++ b/lib/octicons_react/src/__tests__/octicon.js
@@ -69,6 +69,23 @@ describe('An icon component', () => {
     expect(container.querySelector('svg')).toHaveAttribute('aria-label', 'icon')
   })
 
+  it('respects the focusable prop', () => {
+    const {container} = render(<AlertIcon focusable="true" />)
+    expect(container.querySelector('svg')).toHaveAttribute('focusable', true)
+  })
+
+  it('sets focusable false if ariaLabel prop is not present', () => {
+    const {container} = render(<AlertIcon />)
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+    expect(container.querySelector('svg')).toHaveAttribute('focusable', 'false')
+  })
+
+  it('sets focusable prop to given value if ariaLabel prop is present', () => {
+    const {container} = render(<AlertIcon aria-label="icon" focusable="auto" />)
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'false')
+    expect(container.querySelector('svg')).toHaveAttribute('focusable', 'auto')
+  })
+
   it('respects the className prop', () => {
     const {container} = render(<AlertIcon className="foo" />)
     expect(container.querySelector('svg')).toHaveAttribute('class', 'foo')

--- a/lib/octicons_react/src/__tests__/octicon.js
+++ b/lib/octicons_react/src/__tests__/octicon.js
@@ -69,20 +69,13 @@ describe('An icon component', () => {
     expect(container.querySelector('svg')).toHaveAttribute('aria-label', 'icon')
   })
 
-  it('respects the focusable prop', () => {
-    const {container} = render(<AlertIcon focusable="true" />)
-    expect(container.querySelector('svg')).toHaveAttribute('focusable', true)
-  })
-
-  it('sets focusable false if ariaLabel prop is not present', () => {
-    const {container} = render(<AlertIcon />)
-    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+  it('set the focusable prop to false if ariaLabel prop is not present', () => {
+    const {container} = render(<AlertIcon focusable={true} />)
     expect(container.querySelector('svg')).toHaveAttribute('focusable', 'false')
   })
 
   it('sets focusable prop to given value if ariaLabel prop is present', () => {
     const {container} = render(<AlertIcon aria-label="icon" focusable="auto" />)
-    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'false')
     expect(container.querySelector('svg')).toHaveAttribute('focusable', 'auto')
   })
 

--- a/lib/octicons_react/src/__tests__/octicon.js
+++ b/lib/octicons_react/src/__tests__/octicon.js
@@ -69,14 +69,21 @@ describe('An icon component', () => {
     expect(container.querySelector('svg')).toHaveAttribute('aria-label', 'icon')
   })
 
-  it('set the focusable prop to false if ariaLabel prop is not present', () => {
-    const {container} = render(<AlertIcon focusable={true} />)
+  it('set the focusable prop to false if tabIndex prop is not present', () => {
+    const {container} = render(<AlertIcon />)
     expect(container.querySelector('svg')).toHaveAttribute('focusable', 'false')
   })
 
-  it('sets focusable prop to given value if ariaLabel prop is present', () => {
-    const {container} = render(<AlertIcon aria-label="icon" focusable="auto" />)
-    expect(container.querySelector('svg')).toHaveAttribute('focusable', 'auto')
+  it('sets focusable prop to true if tabIndex prop is present and greater than 0', () => {
+    const {container} = render(<AlertIcon aria-label="icon" tabIndex={0} />)
+    expect(container.querySelector('svg')).toHaveAttribute('tabindex', '0')
+    expect(container.querySelector('svg')).toHaveAttribute('focusable', 'true')
+  })
+
+  it('sets focusable prop to false if tabIndex prop is -1', () => {
+    const {container} = render(<AlertIcon aria-label="icon" tabIndex={-1} />)
+    expect(container.querySelector('svg')).toHaveAttribute('tabindex', '-1')
+    expect(container.querySelector('svg')).toHaveAttribute('focusable', 'false')
   })
 
   it('respects the className prop', () => {

--- a/lib/octicons_react/src/createIconComponent.js
+++ b/lib/octicons_react/src/createIconComponent.js
@@ -10,7 +10,7 @@ export function createIconComponent(name, defaultClassName, getSVGData) {
   const svgDataByHeight = getSVGData()
   const heights = Object.keys(svgDataByHeight)
 
-  function Icon({'aria-label': ariaLabel, className, fill = 'currentColor', size, verticalAlign}) {
+  function Icon({'aria-label': ariaLabel, focusable = false, className, fill = 'currentColor', size, verticalAlign}) {
     const height = sizeMap[size] || size
     const naturalHeight = closestNaturalHeight(heights, height)
     const naturalWidth = svgDataByHeight[naturalHeight].width
@@ -20,6 +20,7 @@ export function createIconComponent(name, defaultClassName, getSVGData) {
     return (
       <svg
         aria-hidden={ariaLabel ? 'false' : 'true'}
+        focusable={ariaLabel ? focusable : false}
         aria-label={ariaLabel}
         role="img"
         className={className}

--- a/lib/octicons_react/src/createIconComponent.js
+++ b/lib/octicons_react/src/createIconComponent.js
@@ -10,7 +10,7 @@ export function createIconComponent(name, defaultClassName, getSVGData) {
   const svgDataByHeight = getSVGData()
   const heights = Object.keys(svgDataByHeight)
 
-  function Icon({'aria-label': ariaLabel, focusable = false, className, fill = 'currentColor', size, verticalAlign}) {
+  function Icon({'aria-label': ariaLabel, tabIndex, className, fill = 'currentColor', size, verticalAlign}) {
     const height = sizeMap[size] || size
     const naturalHeight = closestNaturalHeight(heights, height)
     const naturalWidth = svgDataByHeight[naturalHeight].width
@@ -20,7 +20,8 @@ export function createIconComponent(name, defaultClassName, getSVGData) {
     return (
       <svg
         aria-hidden={ariaLabel ? 'false' : 'true'}
-        focusable={ariaLabel ? focusable : false}
+        tabIndex={tabIndex}
+        focusable={tabIndex >= 0 ? 'true' : 'false'}
         aria-label={ariaLabel}
         role="img"
         className={className}

--- a/lib/octicons_react/src/index.d.ts
+++ b/lib/octicons_react/src/index.d.ts
@@ -6,6 +6,7 @@ type Size = 'small' | 'medium' | 'large'
 
 export interface OcticonProps {
   'aria-label'?: string
+  focusable?: boolean | 'auto'
   children?: React.ReactElement<any>
   className?: string
   fill?: string

--- a/lib/octicons_react/src/index.d.ts
+++ b/lib/octicons_react/src/index.d.ts
@@ -6,7 +6,7 @@ type Size = 'small' | 'medium' | 'large'
 
 export interface OcticonProps {
   'aria-label'?: string
-  focusable?: boolean | 'auto'
+  tabIndex?: number
   children?: React.ReactElement<any>
   className?: string
   fill?: string


### PR DESCRIPTION
👋🏼 This PR adds a new prop `focusable` to the `Icon` React component. It is a feedback came from the accessibility review. Please see the comment `Add focusable="false" to SVG icons` [here](https://github.com/github/primer/issues/921#issuecomment-1267507562) 

I don't have much knowledge around svg icons so please let me know if this is a good way of doing it or any other feedback, I would appreciate 🙏🏼 
