### PR TITLE
chore: update rollup config

### DIFF
--- a/lib/octicons_styled/rollup.config.js
+++ b/lib/octicons_styled/rollup.config.js
@@ -11,7 +11,11 @@ export default [
     plugins: [
       babel({
         babelrc: false,
-        presets: [['env', {modules: false}], 'stage-0', 'react']
+        presets: [
+          [require.resolve('babel-preset-env'), {modules: false}],
+          require.resolve('babel-preset-stage-0'),
+          require.resolve('babel-preset-react')
+        ]
       }),
       commonjs()
     ],
@@ -26,7 +30,11 @@ export default [
     plugins: [
       babel({
         babelrc: false,
-        presets: [['env', {modules: false}], 'stage-0', 'react']
+        presets: [
+          [require.resolve('babel-preset-env'), {modules: false}],
+          require.resolve('babel-preset-stage-0'),
+          require.resolve('babel-preset-react')
+        ]
       }),
       commonjs()
     ],


### PR DESCRIPTION
The `@primer/styled-octicons` step in the react job is currently failing: https://github.com/primer/octicons/actions/runs/3208168870/jobs/5243790946

This PR updates the rollup config for `lib/styled_octicons` to resolve presets relative to the package instead of the files. This should address the error where the babel rollup plugin is unable to find the presets/plugins that it's looking for.