### PR TITLE
Update LICENSE to 2023

### DIFF
--- a/.changeset/smooth-cameras-help.md
+++ b/.changeset/smooth-cameras-help.md
@@ -1,0 +1,5 @@
+---
+'@primer/octicons': minor
+---
+
+Updated LICENSE to 2023

--- a/.changeset/smooth-cameras-help.md
+++ b/.changeset/smooth-cameras-help.md
@@ -1,5 +1,0 @@
----
-'@primer/octicons': minor
----
-
-Updated LICENSE to 2023

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 GitHub Inc.
+Copyright (c) 2023 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/octicons_gem/LICENSE
+++ b/lib/octicons_gem/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 GitHub Inc.
+Copyright (c) 2023 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/octicons_helper/LICENSE
+++ b/lib/octicons_helper/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 GitHub Inc.
+Copyright (c) 2023 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/octicons_jekyll/LICENSE
+++ b/lib/octicons_jekyll/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 GitHub Inc.
+Copyright (c) 2023 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/octicons_node/LICENSE
+++ b/lib/octicons_node/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 GitHub Inc.
+Copyright (c) 2023 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/octicons_react/LICENSE
+++ b/lib/octicons_react/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 GitHub Inc.
+Copyright (c) 2023 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/octicons_styled/LICENSE
+++ b/lib/octicons_styled/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 GitHub Inc.
+Copyright (c) 2023 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fixes failing tests on `main` branch, by updating the License to 2023 instead of 2022. 

- Updated LICENSE
- Added changeset so that the updated license goes into the next release