### PR TITLE
feat(octicons-react): add files to package.json and update npmignore

### DIFF
--- a/.changeset/mighty-berries-behave.md
+++ b/.changeset/mighty-berries-behave.md
@@ -1,0 +1,5 @@
+---
+"@primer/octicons-react": minor
+---
+
+Update the npm package for `@primer/octicons-react` to include the `exports` field and explicitly list out files in `package.json`

--- a/lib/octicons_react/.npmignore
+++ b/lib/octicons_react/.npmignore
@@ -7,4 +7,6 @@
 .next
 script
 src
-./pages
+**/pages/**
+**/__tests__/**
+**/ts-tests/**

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -19,6 +19,10 @@
     "ts-test": "tsc -P ts-tests",
     "posttest": "yarn ts-test"
   },
+  "files": [
+    "build",
+    "dist"
+  ],
   "keywords": [
     "GitHub",
     "icons",

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
+  "exports": {
+    "import": "dist/index.esm.js",
+    "require": "dist/index.umd.js"
+  },
   "sideEffects": false,
   "types": "dist/index.d.ts",
   "repository": "primer/octicons",


### PR DESCRIPTION
Update the `package.json` and `.npmignore` for the `@primer/octicons-react` package. Specifically,

- Add the `files` array to `package.json` to include only the files needed for publish
- Update the `.npmignore` file to match on patterns currently being included in the package
- Add the `exports` field to `package.json` with the `import` and `require` keys