### PR TITLE
Update changeset package name

### DIFF
--- a/.changeset/mighty-berries-behave.md
+++ b/.changeset/mighty-berries-behave.md
@@ -1,5 +1,5 @@
 ---
-"@primer/octicons-react": minor
+"@primer/octicons": minor
 ---
 
 Update the npm package for `@primer/octicons-react` to include the `exports` field and explicitly list out files in `package.json`


### PR DESCRIPTION
Update the changeset package name from `@primer/octicons-react` to `@primer/octicons`. I believe this should should fix the broken release builds that started in: https://github.com/primer/octicons/actions/runs/3940904867/jobs/6742606121 which are unable to find the `@primer/octicons-react` package