### PR TITLE
fix(exports): prefix relative paths with `./`

### DIFF
--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -8,8 +8,8 @@
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
   "exports": {
-    "import": "dist/index.esm.js",
-    "require": "dist/index.umd.js"
+    "import": "./dist/index.esm.js",
+    "require": "./dist/index.umd.js"
   },
   "sideEffects": false,
   "types": "dist/index.d.ts",


### PR DESCRIPTION
follow up to https://github.com/primer/octicons/pull/895/files#r1087113669