### PR TITLE
Add `types` exports field for TypeScript ESM

### DIFF
--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -8,6 +8,7 @@
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.esm.js",
     "require": "./dist/index.umd.js"
   },


### PR DESCRIPTION
This is [required](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) for TypeScript to work under `"module": "node16"`, see https://github.com//microsoft/TypeScript/issues/47792.