### PR TITLE
Update the node version and GH actions in workflows

### DIFF
--- a/.github/actions/build_node/Dockerfile
+++ b/.github/actions/build_node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:18-slim
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \

--- a/.github/actions/build_node/Dockerfile
+++ b/.github/actions/build_node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:20-slim
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - run: yarn
       - name: Building
         run: yarn build
       - run: cp -r icons lib/build/svg
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: octicons-build
           path: ./lib/build
@@ -27,11 +27,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14
-      - uses: actions/download-artifact@v2
+          node-version: 18
+      - uses: actions/download-artifact@v3
         with:
           name: octicons-build
           path: ./lib/build
@@ -49,11 +49,11 @@ jobs:
       run:
         working-directory: ./lib/octicons_node
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14
-      - uses: actions/download-artifact@v2
+          node-version: 18
+      - uses: actions/download-artifact@v3
         with:
           name: octicons-build
           path: ./lib/build
@@ -73,11 +73,11 @@ jobs:
       run:
         working-directory: ./lib/octicons_react
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14
-      - uses: actions/download-artifact@v2
+          node-version: 18
+      - uses: actions/download-artifact@v3
         with:
           name: octicons-build
           path: ./lib/build
@@ -97,12 +97,12 @@ jobs:
       run:
         working-directory: ./lib/octicons_gem
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: octicons-build
           path: ./lib/octicons_gem/lib/build
@@ -126,12 +126,12 @@ jobs:
       run:
         working-directory: ./lib/octicons_helper
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: octicons-gem
           path: ./lib/octicons_helper/vendor/cache
@@ -149,12 +149,12 @@ jobs:
       run:
         working-directory: ./lib/octicons_jekyll
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: octicons-gem
           path: ./lib/octicons_jekyll/vendor/cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: '10.x'
+          node-version: '18.x'
       - run: npm install
       - run: npm run build
       - run: cp -r icons lib/build/svg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Closes https://github.com/primer/octicons/issues/946

Octicons are failed to be publish to NPM due to an [error](https://github.com/primer/octicons/actions/runs/4919743480/jobs/8793883454) while fetching the docker image to build nodes. 

Apparently Debian 9/stretch moved to archive.debian.org ([reference](https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html))

Found through this thread: https://unix.stackexchange.com/questions/743839/apt-get-update-failed-to-fetch-debian-amd64-packages-while-building-dockerfile-f

Also updating all other node versions and GH actions.