### PR TITLE
Use the Primer GitHub App for auth instead of the GPR_AUTH_TOKEN_SHARED

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,15 @@ jobs:
           yarn
           bundle install
 
+      - id: get-access-token
+        uses: camertron/github-app-installation-auth-action@v1
+        with:
+          app-id: ${{ vars.PRIMER_APP_ID_SHARED }}
+          private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
+          client-id: ${{ vars.PRIMER_APP_CLIENT_ID_SHARED }}
+          client-secret: ${{ secrets.PRIMER_APP_CLIENT_SECRET_SHARED }}
+          installation-id: ${{ vars.PRIMER_APP_INSTALLATION_ID_SHARED }}
+
       - name: Create release pull request or publish to npm
         id: changesets
         uses: changesets/action@master
@@ -41,5 +50,5 @@ jobs:
           version: yarn changeset:version
           publish: script/changeset-publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
+          GITHUB_TOKEN: ${{ steps.get-access-token.outputs.access-token }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}


### PR DESCRIPTION
This PR replaces usage of the `GPR_AUTH_TOKEN_SHARED` PAT with a token obtained through the Primer GitHub App in several CI scenarios.

Fixes https://github.com/github/primer/issues/2540