### PR TITLE
Bump rubocop and rubocop-github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source "https://rubygems.org"
 group :development, :test do
   gem "minitest"
   gem "rake"
-  gem "rubocop", "0.59"
-  gem "rubocop-github", "0.12.0"
+  gem "rubocop", "1.57"
+  gem "rubocop-github", "0.20.0"
 end

--- a/lib/octicons_gem/Gemfile
+++ b/lib/octicons_gem/Gemfile
@@ -5,6 +5,6 @@ gemspec
 group :development, :test do
   gem "minitest"
   gem "rake"
-  gem "rubocop", "0.59"
-  gem "rubocop-github", "0.12.0"
+  gem "rubocop", "1.57"
+  gem "rubocop-github", "0.20.0"
 end

--- a/lib/octicons_helper/Gemfile
+++ b/lib/octicons_helper/Gemfile
@@ -8,6 +8,6 @@ gem "rails"
 group :development, :test do
   gem "minitest"
   gem "rake"
-  gem "rubocop", "0.59"
-  gem "rubocop-github", "0.12.0"
+  gem "rubocop", "1.57"
+  gem "rubocop-github", "0.20.0"
 end

--- a/lib/octicons_jekyll/Gemfile
+++ b/lib/octicons_jekyll/Gemfile
@@ -7,6 +7,6 @@ gem "octicons", "19.8.0"
 group :development, :test do
   gem "minitest"
   gem "rake"
-  gem "rubocop", "0.59"
-  gem "rubocop-github", "0.12.0"
+  gem "rubocop", "1.57"
+  gem "rubocop-github", "0.20.0"
 end


### PR DESCRIPTION
### Problem

Currently, on every PR the CI is failing on the `gem:octicons_helper` step when Linting with the following error: `wrong number of arguments (given 5, expected 1)`. This happens due to the rubocop gem being outdated quite some bit.

### Examples

See the currently opened PR:

* https://github.com/primer/octicons/actions/runs/6894514777/job/18756561098?pr=993
* https://github.com/primer/octicons/actions/runs/6509637913/job/17681662960?pr=983

### Solution

The `rubocop` and the `rubocop-github` gems are updated to the current versions. 
