### PR TITLE
Avoid duplicate build folder in @primer/octicons

### DIFF
--- a/lib/octicons_node/package.json
+++ b/lib/octicons_node/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/primer/octicons/issues"
   },
   "scripts": {
-    "build": "\\cp -r ../build/ ./build && \\cp index.scss ./build/build.css",
+    "build": "\\cp -r ../build/. ./build && \\cp index.scss ./build/build.css",
     "lint": "eslint index.js tests/*.js",
     "test": "ava --verbose 'tests/*.js'"
   },


### PR DESCRIPTION
- Probably fixes https://github.com/primer/octicons/issues/699 

In my local tests, running `yarn build` in `lib/octicons_node` generates `build/build/svg` but after this change it generates `build/svg`, so it should fix the issue.

However the build is a bit of spaghetti between workflows, docker entrypoints.js and multiple package.json, so it's not entirely clear if further work is required (probably not)