### PR TITLE
fix(octicons_react): remove build from npm package files

### DIFF
--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -25,7 +25,6 @@
     "posttest": "yarn ts-test"
   },
   "files": [
-    "build",
     "dist"
   ],
   "keywords": [


### PR DESCRIPTION
Closes https://github.com/primer/octicons/pull/1002

This removes `build` from the list of `files` for the npm package. These files are not accessible since we currently use the `exports` field so removing this should be compatible within semver (but let me know if not!)