### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-*    @primer/octicons-reviewers
+*        @primer/engineer-reviewers
+icons    @primer/octicons-reviewers


### PR DESCRIPTION
Wanted to propose a change to `CODEOWNERS` to help with getting through the PR reviews currently in the project 👀 

Let me know what you think! With this setup, I wanted to make sure that `icons` still mapped to `octicon-reviewers` and changes to code/packages mapped to `engineer-reviewers`