### PR TITLE
Remove Octicon example from react README.md

### DIFF
--- a/lib/octicons_react/README.md
+++ b/lib/octicons_react/README.md
@@ -158,20 +158,6 @@ export default () => (
 )
 ```
 
-
-```diff
-- <Octicon icon={AlertIcon} />
-+ <AlertIcon />
-```
-
-The `Octicon` component is wrapper that passes props to its icon component. To render a specific icon, you
-can pass it either via the `icon` prop, or as the only child:
-
-```jsx
-<Octicon icon={Icon} />
-<Octicon><Icon x={10}/></Octicon>
-```
-
 [octicons]: https://primer.style/octicons/
 [primer]: https://github.com/primer/primer
 [docs]: http://primercss.io/


### PR DESCRIPTION
Looks like 697bf97f1dcd6490dff1515e976b311460680b15 only deleted the section title, not the actual section in the README