### PR TITLE
chore: update changeset to reference octicons package

### DIFF
--- a/.changeset/spicy-actors-act.md
+++ b/.changeset/spicy-actors-act.md
@@ -1,5 +1,5 @@
 ---
-'@primer/octicons-react': patch
+'@primer/octicons': patch
 ---
 
 Update octicons in React to no longer set role="img" if the icon is aria-hidden

--- a/.changeset/tasty-countries-grow.md
+++ b/.changeset/tasty-countries-grow.md
@@ -1,5 +1,5 @@
 ---
-'@primer/octicons-react': minor
+'@primer/octicons': minor
 ---
 
 Update ESM import to use mjs extension when in parent CommonJS module


### PR DESCRIPTION
Noticed that our release action is failing since changesets is unable to find `@primer/octicons-react`. This updates the changesets to reference `@primer/octicons` which I think is the convention to trigger releases (let me know if that's wrong!)