### PR TITLE
Fix versioning script that updates the version files

### DIFF
--- a/lib/octicons_gem/Rakefile
+++ b/lib/octicons_gem/Rakefile
@@ -14,7 +14,7 @@ Rake::TestTask.new do |t|
 end
 
 task :version, [:v] do |t, args|
-  out = "module Octicons\n"\
+  out = "# frozen_string_literal: true\n\nmodule Octicons\n"\
     "  VERSION = \"#{args[:v]}\".freeze\n"\
     "end"
   File.open(File.expand_path("../lib/octicons/version.rb", __FILE__), "w") { |file| file.puts out }

--- a/lib/octicons_helper/Rakefile
+++ b/lib/octicons_helper/Rakefile
@@ -9,7 +9,7 @@ RuboCop::RakeTask.new(:lint) do |t|
 end
 
 task :version, [:v] do |t, args|
-  out = "module OcticonsHelper\n"\
+  out = "# frozen_string_literal: true\n\nmodule OcticonsHelper\n"\
     "  VERSION = \"#{args[:v]}\".freeze\n"\
     "end"
   File.open(File.expand_path("../lib/octicons_helper/version.rb", __FILE__), "w") do |file|

--- a/lib/octicons_jekyll/Rakefile
+++ b/lib/octicons_jekyll/Rakefile
@@ -9,7 +9,7 @@ RuboCop::RakeTask.new(:lint) do |t|
 end
 
 task :version, [:v] => :environment do |t, args|
-  out = "# Prevent bundler errors\n"\
+  out = "# frozen_string_literal: true\n\n# Prevent bundler errors\n"\
   "module Liquid; class Tag; end; end\n\n"\
   "module Jekyll\n"\
   "  class Octicons < Liquid::Tag\n"\


### PR DESCRIPTION
There's a lint error in #1014 that is caused because when changesets is versioning it's removing the lint comment https://github.com/primer/octicons/commit/9f09f452d8376158380938e84d2691e5f084a175