### PR TITLE
fix(octicons_react): include extension in type declaration

### DIFF
--- a/.changeset/blue-crabs-tie.md
+++ b/.changeset/blue-crabs-tie.md
@@ -1,0 +1,5 @@
+---
+'@primer/octicons': patch
+---
+
+Update types for @primer/octicons-react to explicitly include extensions for different moduleResolution settings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,8 @@ jobs:
         run: yarn test
       - name: Types
         run: |
-          yarn pack
-          VERSION=$(jq -r '.version' package.json)
-
           # Run @arethetypeswrong/cli
-          npx @arethetypeswrong/cli --pack 'primer-octicons-react-v$VERSION.tgz'
+          npx @arethetypeswrong/cli --pack .
 
           # Run publint
           npx publint . --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,16 @@ jobs:
         run: yarn lint
       - name: Test
         run: yarn test
+      - name: Types
+        run: |
+          yarn pack
+          VERSION=$(jq -r '.version' package.json)
+
+          # Run @arethetypeswrong/cli
+          npx @arethetypeswrong/cli --pack 'primer-octicons-react-v$VERSION.tgz'
+
+          # Run publint
+          npx publint . --strict
 
   octicons_gem:
     name: 'gem:octicons'

--- a/lib/octicons_react/src/index.d.ts
+++ b/lib/octicons_react/src/index.d.ts
@@ -2,7 +2,7 @@
 import * as React from 'react'
 
 // eslint-disable-next-line prettier/prettier
-import { Icon } from './__generated__/icons'
+import {Icon} from './__generated__/icons.js'
 
 type Size = 'small' | 'medium' | 'large'
 
@@ -20,4 +20,4 @@ export interface OcticonProps {
   verticalAlign?: 'middle' | 'text-bottom' | 'text-top' | 'top' | 'unset'
 }
 
-export * from './__generated__/icons'
+export * from './__generated__/icons.js'


### PR DESCRIPTION
Closes #1018 

Add an explicit extension for the types to support different `moduleResolution` options. This also adds in a step to the CI to run `arethetypeswrong` to make sure that we don't regress here in the future 👀 