### PR TITLE
Removed small blue link thing caused by `<a>` it readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@
 
 <p align="center">
   <a aria-label="build status" href="https://github.com/primer/octicons/actions/workflows/ci.yml">
-    <img alt="" src="https://github.com/primer/octicons/actions/workflows/ci.yml/badge.svg?branch=main&event=push">
-  </a>
+    <img alt="" src="https://github.com/primer/octicons/actions/workflows/ci.yml/badge.svg?branch=main&event=push"></a>
   <a aria-label="publish status" href="https://github.com/primer/octicons/actions/workflows/publish.yml">
-    <img alt="" src="https://github.com/primer/octicons/actions/workflows/publish.yml/badge.svg">
-  </a>
+    <img alt="" src="https://github.com/primer/octicons/actions/workflows/publish.yml/badge.svg"></a>
 </p>
 
 ## Libraries


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e36c4d81-dce4-4815-a08d-7a7dba9c5143)
There is tiny blue line caused by linebreaks in `<a>` tags.

Might be fixed by removeing unnecessary linebreak