### PR TITLE
Add documentation for style prop in React Octicons

### DIFF
--- a/lib/octicons_react/README.md
+++ b/lib/octicons_react/README.md
@@ -158,6 +158,21 @@ export default () => (
 )
 ```
 
+### Style
+
+The `style` prop takes an object value that can be used to set inline styles for the icon.
+
+```js
+// Example usage
+import {SparkleFillIcon} from '@primer/octicons-react'
+export default () => (
+  <h1>
+    <SparkleFillIcon style={{color: 'blue', marginRight: '10px'}} />
+    Sparkle
+  </h1>
+)
+```
+
 [octicons]: https://primer.style/octicons/
 [primer]: https://github.com/primer/primer
 [docs]: http://primercss.io/


### PR DESCRIPTION
Fixes #1040

Add documentation for the'style` prop in the React Octicon components.

* Add a new section in `lib/octicons_react/README.md` explaining the usage of the'style` prop.
* Provide an example of using the'style` prop to apply inline styles to an icon.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/primer/octicons/pull/1052?shareId=e596cd67-0604-47f1-95e6-cb3fb37ca24c).