### PR TITLE
Disable Rails/Delegate linter for parse method in test/helper.rb

### DIFF
--- a/lib/octicons_jekyll/test/helper.rb
+++ b/lib/octicons_jekyll/test/helper.rb
@@ -4,9 +4,11 @@ require "minitest/autorun"
 require "jekyll-octicons"
 
 # Parse a string into a liquid template
+# rubocop:disable Rails/Delegate
 def parse(string)
   Liquid::Template.parse(string)
 end
+# rubocop:enable Rails/Delegate
 
 # Parse and render a string
 def render(string, assigns = {})


### PR DESCRIPTION
This is not a straightforward fix b/c `#parse` is defined in the global scope, so let's just disable it.