### PR TITLE
Add checkboxfill-16.svg and checkboxfill-24.svg

### DIFF
--- a/keywords.json
+++ b/keywords.json
@@ -34,6 +34,8 @@
   "bug": ["insect", "issue"],
   "calendar": ["time", "day", "month", "year", "date", "appointment"],
   "check": ["mark", "yes", "confirm", "accept", "ok", "success"],
+  "checkbox": ["box", "checkbox", "check"],
+  "checkbox-fill": ["box", "checkbox", "check"],
   "checklist": ["todo", "tasks"],
   "chevron-down": ["triangle", "arrow"],
   "chevron-left": ["triangle", "arrow"],


### PR DESCRIPTION
Creating a filled version of the [Checkbox octicon](https://primer.style/octicons/icon/checkbox-16/)

![CleanShot 2025-09-08 at 20 44 27@2x](https://github.com/user-attachments/assets/fe5d5f5a-6bde-4abc-8f76-5016eac5e4ad)
