### PR TITLE
Update .rubocop.yml to exclude version.rb from checks

### DIFF
--- a/lib/octicons_jekyll/.rubocop.yml
+++ b/lib/octicons_jekyll/.rubocop.yml
@@ -5,5 +5,9 @@ inherit_gem:
 Naming/FileName:
   Enabled: false
 
+Style/OneClassPerFile:
+  Exclude:
+    - "lib/jekyll-octicons/version.rb"
+
 AllCops:
   NewCops: enable


### PR DESCRIPTION
Update .rubocop.yml to exclude version.rb from checks to unblock [CI / gem:octicons_jekyll (pull_request)](https://github.com/primer/octicons/actions/runs/22740094639/job/65951777997?pr=1166) against main