### PR TITLE
Add data-component attribute to Octicon SVGs

### DIFF
--- a/.changeset/add-data-component-attribute.md
+++ b/.changeset/add-data-component-attribute.md
@@ -1,0 +1,7 @@
+---
+"@primer/octicons": minor
+"@primer/octicons-react": minor
+"@primer/styled-octicons": minor
+---
+
+Add `data-component="Octicon"` attribute to all SVG elements for easier identification and styling

--- a/lib/octicons_gem/lib/octicons/octicon.rb
+++ b/lib/octicons_gem/lib/octicons/octicon.rb
@@ -17,7 +17,8 @@ module Octicons
         @options.merge!({
           class:   classes,
           viewBox: viewbox,
-          version: "1.1"
+          version: "1.1",
+          "data-component": "Octicon"
         })
         @options.merge!(size)
         @options.merge!(a11y)

--- a/lib/octicons_gem/test/octicon_test.rb
+++ b/lib/octicons_gem/test/octicon_test.rb
@@ -134,4 +134,11 @@ describe Octicons::Octicon do
       assert_includes icon.to_svg, "aria-hidden=\"true\""
     end
   end
+
+  describe "data-component" do
+    it "has data-component attribute" do
+      icon = octicon("x")
+      assert_includes icon.to_svg, "data-component=\"Octicon\""
+    end
+  end
 end

--- a/lib/octicons_node/index.js
+++ b/lib/octicons_node/index.js
@@ -55,7 +55,8 @@ for (const key of Object.keys(data)) {
       height: parseInt(height),
       viewBox: `0 0 ${data[key].heights[height].width} ${height}`,
       class: `octicon octicon-${key}`,
-      'aria-hidden': 'true'
+      'aria-hidden': 'true',
+      'data-component': 'Octicon'
     }
   }
 

--- a/lib/octicons_node/tests/index.js
+++ b/lib/octicons_node/tests/index.js
@@ -27,11 +27,7 @@ test('Octicons have default html attributes', t => {
       new RegExp(`class="octicon octicon-${octicons[point].symbol}"`),
       `The octicon "${point}" doesn't have the class attribute`
     )
-    t.regex(
-      svg,
-      /data-component="Octicon"/,
-      `The octicon "${point}" doesn't have the data-component attribute`
-    )
+    t.regex(svg, /data-component="Octicon"/, `The octicon "${point}" doesn't have the data-component attribute`)
   }
 })
 

--- a/lib/octicons_node/tests/index.js
+++ b/lib/octicons_node/tests/index.js
@@ -27,6 +27,11 @@ test('Octicons have default html attributes', t => {
       new RegExp(`class="octicon octicon-${octicons[point].symbol}"`),
       `The octicon "${point}" doesn't have the class attribute`
     )
+    t.regex(
+      svg,
+      /data-component="Octicon"/,
+      `The octicon "${point}" doesn't have the data-component attribute`
+    )
   }
 })
 

--- a/lib/octicons_react/__tests__/tree-shaking.test.js
+++ b/lib/octicons_react/__tests__/tree-shaking.test.js
@@ -50,5 +50,5 @@ test('tree shaking single export', async () => {
   })
 
   const bundleSize = Buffer.byteLength(output[0].code.trim()) / 1000
-  expect(`${bundleSize}kB`).toMatchInlineSnapshot(`"6.084kB"`)
+  expect(`${bundleSize}kB`).toMatchInlineSnapshot(`"6.119kB"`)
 })

--- a/lib/octicons_react/src/__tests__/__snapshots__/octicon.js.snap
+++ b/lib/octicons_react/src/__tests__/__snapshots__/octicon.js.snap
@@ -4,6 +4,7 @@ exports[`An icon component matches snapshot 1`] = `
 <svg
   aria-hidden="true"
   class="octicon octicon-alert"
+  data-component="Octicon"
   display="inline-block"
   fill="currentColor"
   focusable="false"

--- a/lib/octicons_react/src/__tests__/octicon.js
+++ b/lib/octicons_react/src/__tests__/octicon.js
@@ -14,6 +14,11 @@ describe('An icon component', () => {
     expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
   })
 
+  it('has `data-component="Octicon"` attribute', () => {
+    const {container} = render(<AlertIcon />)
+    expect(container.querySelector('svg')).toHaveAttribute('data-component', 'Octicon')
+  })
+
   it('sets `role="img"` if `aria-label` is provided', () => {
     render(<AlertIcon aria-label="Alert" />)
     expect(screen.getByLabelText('Alert')).toHaveAttribute('role', 'img')

--- a/lib/octicons_react/src/createIconComponent.js
+++ b/lib/octicons_react/src/createIconComponent.js
@@ -53,6 +53,7 @@ export function createIconComponent(name, defaultClassName, getSVGData) {
           id={id}
           display="inline-block"
           overflow="visible"
+          data-component="Octicon"
           style={{
             verticalAlign,
             ...style


### PR DESCRIPTION
Towards https://github.com/github/primer/issues/6497