### PR TITLE
Rename skip-changeset label to "skip changeset"

### DIFF
--- a/.github/workflows/check_for_changeset.yml
+++ b/.github/workflows/check_for_changeset.yml
@@ -7,7 +7,7 @@ on:
       - 'opened'
       - 'reopened'
       - 'synchronize'
-      # For `skip-label` only.
+      # For `skip changeset` only.
       - 'labeled'
       - 'unlabeled'
 
@@ -21,5 +21,5 @@ jobs:
         uses: brettcannon/check-for-changed-files@v1
         with:
           file-pattern: '.changeset/*.md'
-          skip-label: 'skip-changeset'
+          skip-label: 'skip changeset'
           failure-message: 'No changeset found. If these changes should not result in a new version, apply the ${skip-label} label to this pull request. If these changes should result in a version bump, please add a changeset https://git.io/J6QvQ'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,6 @@ Once maintainers have agreed and are satisfied with the release. Merge the Relea
 
 ## Other contributions
 
-When contributing to Octicons outside of adding a new icon or release-dependent contribution, be sure to add the `skip-changeset` label to the pull request. This will allow for the pull request to skip the changeset check and have the ability to be merged into the main branch. 
+When contributing to Octicons outside of adding a new icon or release-dependent contribution, be sure to add the `skip changeset` label to the pull request. This will allow for the pull request to skip the changeset check and have the ability to be merged into the main branch. 
 
 Examples of other contributions include adding documentation or improving a GitHub Actions workflows.


### PR DESCRIPTION
the [dependabot workflow](https://github.com/primer/octicons/blob/main/.github/dependabot.yml#L16) was not adding `skip changeset` label correctly. Turns out all our other repos have `skip changeset` while this repo has `skip-changeset`. Making it the same