### PR TITLE
Scope SVG optimize workflow to only changed icons

### DIFF
--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -15,19 +15,49 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - name: Get changed icons
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} -- 'icons/*.svg')
+          else
+            CHANGED=$(git diff --name-only --diff-filter=AM ${{ github.event.before }} -- 'icons/*.svg')
+          fi
+          if [ -z "$CHANGED" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "files<<EOF" >> $GITHUB_OUTPUT
+            echo "$CHANGED" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
 
       - uses: actions/setup-python@v4
+        if: steps.changed.outputs.has_changes == 'true'
         with:
           python-version: '3.10' 
           cache: 'pip'
       - run: pip install -r .github/actions/python/requirements.txt
-      - run: for icon in icons/*; do picosvg $icon --output_file $icon; done
+        if: steps.changed.outputs.has_changes == 'true'
+      - name: Run picosvg on changed icons
+        if: steps.changed.outputs.has_changes == 'true'
+        run: |
+          while IFS= read -r icon; do
+            picosvg "$icon" --output_file "$icon"
+          done <<< "${{ steps.changed.outputs.files }}"
 
       - uses: actions/setup-node@v3
+        if: steps.changed.outputs.has_changes == 'true'
         with:
           node-version: 18
       - run: npm install
-      - run: npm run svgo
+        if: steps.changed.outputs.has_changes == 'true'
+      - name: Run svgo on changed icons
+        if: steps.changed.outputs.has_changes == 'true'
+        run: npx svgo --config svgo.config.js ${{ steps.changed.outputs.files }}
 
       - uses: EndBug/add-and-commit@v4
         with:

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -14,7 +14,7 @@ jobs:
   optimize:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -22,9 +22,9 @@ jobs:
         id: changed
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            CHANGED=$(git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} -- 'icons/*.svg')
+            CHANGED=$(git diff --name-only --diff-filter=AMR ${{ github.event.pull_request.base.sha }} -- 'icons/**/*.svg')
           else
-            CHANGED=$(git diff --name-only --diff-filter=AM ${{ github.event.before }} -- 'icons/*.svg')
+            CHANGED=$(git diff --name-only --diff-filter=AMR ${{ github.event.before }} -- 'icons/**/*.svg')
           fi
           if [ -z "$CHANGED" ]; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -60,6 +60,7 @@ jobs:
         run: npx svgo --config svgo.config.js ${{ steps.changed.outputs.files }}
 
       - uses: EndBug/add-and-commit@v4
+        if: steps.changed.outputs.has_changes == 'true'
         with:
           add: 'icons'
           message: 'Optimize SVGs'


### PR DESCRIPTION
## Why

The `optimize.yml` workflow has been processing **every** icon in the repository whenever any icon is added or modified. While this was technically always the case, it was previously harmless because the optimization tools (picosvg, svgo) produced idempotent output. A recent patch update to `picosvg` (pinned as `~=0.20.6`, allowing compatible releases) likely changed its output slightly, causing already-optimized icons to be re-processed with different results -- leading to a commit that touches every icon file.

## What changed

- **Added `fetch-depth: 0`** to the checkout step so full git history is available for diffing
- **Added a "Get changed icons" step** that uses `git diff --diff-filter=AM` to identify only added/modified SVGs in the current PR or push, handling both `pull_request` and `push` event types
- **Scoped picosvg and svgo** to only process the changed files instead of the entire `icons/` directory
- **Added `if` conditions** on all optimization steps so they are skipped entirely when no icons changed (e.g., when only the workflow file itself was edited)

## Notes

- The `picosvg` version pin in `requirements.txt` (`~=0.20.6`) allows compatible patch releases, which is likely what caused the recent behavior change. Consider tightening to `==0.20.6` if strict reproducibility is desired.