### PR TITLE
Fix optimize workflow pathspec to match icons in root directory

### DIFF
--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -22,9 +22,9 @@ jobs:
         id: changed
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            CHANGED=$(git diff --name-only --diff-filter=AMR ${{ github.event.pull_request.base.sha }} -- 'icons/**/*.svg')
+            CHANGED=$(git diff --name-only --diff-filter=AMR ${{ github.event.pull_request.base.sha }} -- 'icons/*.svg' 'icons/**/*.svg')
           else
-            CHANGED=$(git diff --name-only --diff-filter=AMR ${{ github.event.before }} -- 'icons/**/*.svg')
+            CHANGED=$(git diff --name-only --diff-filter=AMR ${{ github.event.before }} -- 'icons/*.svg' 'icons/**/*.svg')
           fi
           if [ -z "$CHANGED" ]; then
             echo "has_changes=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Why

The optimize workflow merged in #1218 uses `icons/**/*.svg` as the git diff pathspec, but this pattern requires at least one subdirectory level. Files directly in `icons/` (e.g., `icons/stack-add-16.svg`) don't match, causing the workflow to skip optimization entirely for new icons. This was observed on PR #1219 where a new icon was not optimized.

## Fix

Use both `icons/*.svg` (files directly in `icons/`) and `icons/**/*.svg` (files in subdirectories) in the pathspec to cover all cases.