### PR TITLE
Optimize '@primer/octicons-react' for codesplitting

### DIFF
--- a/.changeset/octicons-react-codesplitting.md
+++ b/.changeset/octicons-react-codesplitting.md
@@ -1,5 +1,5 @@
 ---
-"@primer/octicons-react": minor
+"@primer/octicons": minor
 ---
 
 Optimize `@primer/octicons-react` for codesplitting and tree-shaking. Each icon is now emitted as its own module and exposed via a `./*` subpath export, so icons can be dynamically imported and code-split (e.g. `import('@primer/octicons-react/AlertIcon')`). The generated icons are now finished `React.forwardRef` components built on a shared `renderOcticon` runtime instead of runtime `createIconComponent` factory calls. Existing `import {AlertIcon}` and `import * as Octicons` usage continues to work unchanged.


### PR DESCRIPTION
Optimize '@primer/octicons-react' for codesplitting and tree-shaking by emitting each icon as its own module. Existing import methods remain unchanged.

<!--
  Thanks for contributing to Octicons!

  If you're adding or modifying an icon, please make sure it follows our
  design guidelines so we can keep the set consistent:
  https://primer.style/foundations/icons/guidelines

  If you want design feedback before your PR is ready, open it as a draft
  and request a review. We're happy to help!
-->

closes https://github.com/primer/octicons/pull/1253
