### PR TITLE
Add default exports to per-icon octicons-react modules

### DIFF
--- a/.changeset/octicons-react-per-icon-default-exports.md
+++ b/.changeset/octicons-react-per-icon-default-exports.md
@@ -1,5 +1,5 @@
 ---
-'@primer/octicons-react': minor
+'@primer/octicons': minor
 ---
 
 Add default exports to per-icon `@primer/octicons-react` subpath modules (e.g. `@primer/octicons-react/AlertIcon`), alongside the existing named exports. Root/barrel APIs remain named-only.


### PR DESCRIPTION
Add default exports for per-icon modules in @primer/octicons-react while keeping root/barrel APIs named-only.

<!--
  Thanks for contributing to Octicons!

  If you're adding or modifying an icon, please make sure it follows our
  design guidelines so we can keep the set consistent:
  https://primer.style/foundations/icons/guidelines

  If you want design feedback before your PR is ready, open it as a draft
  and request a review. We're happy to help!
-->
