### PR TITLE
Fix release gem versioning with Bundler

### DIFF
--- a/script/version
+++ b/script/version
@@ -47,18 +47,14 @@ NODE
 
 echo "Versioning Octicons ruby gem"
 
-cd lib/octicons_gem/
-rake version\["$PACKAGE_VERSION"\]
+bundle exec rake -C lib/octicons_gem version\["$PACKAGE_VERSION"\]
 
 echo "Versioning Octicons rails helper gem"
 
-cd ../octicons_helper/
-rake version\["$PACKAGE_VERSION"\]
+bundle exec rake -C lib/octicons_helper version\["$PACKAGE_VERSION"\]
 
 echo "Versioning Octicons jekyll plugin gem"
 
-cd ../octicons_jekyll/
-rake version\["$PACKAGE_VERSION"\]
+bundle exec rake -C lib/octicons_jekyll version\["$PACKAGE_VERSION"\]
 
-cd ../../
 git add package.json package-lock.json lib/


### PR DESCRIPTION
Follow up to the failing [release workflow](https://github.com/primer/octicons/actions/runs/30396745852/job/90401465511). The Ruby dependencies were installed into `vendor/bundle`, but `script/version` invoked the system `rake`, which could not load `rubocop/rake_task`.

**Changed**

- Run each gem version task through `bundle exec rake`.
- Use Rake’s `-C` option so all commands activate the root bundle before loading each gem Rakefile.

This is a change to our internal release workflow and has no public-facing API impact.

**Validation**

- Ran the full `script/version lib/octicons_node/package.json` flow with the repository bundle.