### PR TITLE
chore(deps): update to typescript v6

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact=true

--- a/lib/octicons_react/package.json
+++ b/lib/octicons_react/package.json
@@ -65,7 +65,7 @@
     "rimraf": "3.0.2",
     "rollup": "^2.79.0",
     "styled-components": "^4.2.0",
-    "typescript": "^4.8.3"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "react": ">=16.3"

--- a/lib/octicons_styled/package.json
+++ b/lib/octicons_styled/package.json
@@ -54,7 +54,7 @@
     "react-dom": "^16.4.1",
     "rollup": "^4.18.0",
     "styled-components": "^5.1.0",
-    "typescript": "^3.7.5"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@changesets/changelog-github": "0.4.1",
         "@changesets/cli": "2.17.0",
         "@github/prettier-config": "0.0.6",
-        "@types/node": "20.19.0",
+        "@types/node": "^26.1.2",
         "@vitejs/plugin-react": "4.7.0",
         "@vitest/browser": "3.2.7",
         "braces": "3.0.3",
@@ -34,6 +34,7 @@
         "svgo": "3.3.4",
         "svgson": "5.2.1",
         "trim-newlines": "3.0.1",
+        "typescript": "^6.0.3",
         "vitest": "3.2.7",
         "yargs": "15.4.1"
       }
@@ -82,7 +83,7 @@
         "rimraf": "3.0.2",
         "rollup": "^2.79.0",
         "styled-components": "^4.2.0",
-        "typescript": "^4.8.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=8"
@@ -120,16 +121,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      }
-    },
-    "lib/octicons_react/node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "lib/octicons_react/node_modules/@github/prettier-config": {
@@ -215,7 +206,7 @@
         "react-dom": "^16.4.1",
         "rollup": "^4.18.0",
         "styled-components": "^5.1.0",
-        "typescript": "^3.7.5"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=8"
@@ -593,20 +584,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "lib/octicons_styled/node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6339,13 +6316,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
-      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -9232,20 +9209,6 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
-      }
-    },
-    "node_modules/eslint-plugin-github/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/eslint-plugin-i18n-text": {
@@ -15245,9 +15208,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -15255,7 +15218,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {
@@ -15302,9 +15265,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@changesets/changelog-github": "0.4.1",
     "@changesets/cli": "2.17.0",
     "@github/prettier-config": "0.0.6",
-    "@types/node": "20.19.0",
+    "@types/node": "^26.1.2",
     "@vitejs/plugin-react": "4.7.0",
     "@vitest/browser": "3.2.7",
     "braces": "3.0.3",
@@ -40,6 +40,7 @@
     "svgo": "3.3.4",
     "svgson": "5.2.1",
     "trim-newlines": "3.0.1",
+    "typescript": "^6.0.3",
     "vitest": "3.2.7",
     "yargs": "15.4.1"
   },


### PR DESCRIPTION
Update our base TypeScript version so the `ts-tests` task runs as expected in our new CI workflow 😄 