### PR TITLE
Update rubocop-github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
           bundler-cache: true
 
       - name: Install dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ source "https://rubygems.org"
 group :development, :test do
   gem "minitest"
   gem "rake"
-  gem "rubocop-github", "0.20.0"
+  gem "rubocop-github", "0.27.0"
 end


### PR DESCRIPTION
This PR updates the Ruby linting dependency at the top of dependency stack #1323.

### Changed

- Update `rubocop-github` from 0.20.0 to 0.27.0.
- Update the release workflow from Ruby 3.2 to Ruby 3.3 to satisfy the new minimum Ruby version.

This is an internal lint and release workflow change and does not change the public API.
