### PR TITLE
Rename workflow from 'Octicons Publish' to 'publish'

### DIFF
--- a/.github/workflows/report-workflow-failures.yml
+++ b/.github/workflows/report-workflow-failures.yml
@@ -3,7 +3,7 @@ name: report workflow failures
 on:
   workflow_run:
     workflows:
-      - Octicons Publish
+      - publish
       - Codespaces Prebuilds
     types:
       - completed


### PR DESCRIPTION
<!--
  Thanks for contributing to Octicons!

  If you're adding or modifying an icon, please make sure it follows our
  design guidelines so we can keep the set consistent:
  https://primer.style/foundations/icons/guidelines

  If you want design feedback before your PR is ready, open it as a draft
  and request a review. We're happy to help!
-->

Update the name of the publish workflow so that our report workflow correctly reports when publish.yml fails 😥 